### PR TITLE
Fix unlock detection in bw-key-init

### DIFF
--- a/bw-key-init.sh
+++ b/bw-key-init.sh
@@ -18,7 +18,7 @@ fi
 # Function to ensure BW_SESSION is set and unlocked
 ensure_session() {
   # If BW_SESSION is unset or expired, login/unlock
-  if [[ -z "$BW_SESSION" ]] || ! bw status --session "$BW_SESSION" | grep -q "Unlocked"; then
+  if [[ -z "$BW_SESSION" ]] || ! bw status --session "$BW_SESSION" | grep -iq "unlocked"; then
     echo "=> Logging into Bitwarden using API key..."
     # Login with API key, output raw session
     export BW_SESSION=$(bw login --apikey --raw)


### PR DESCRIPTION
## Summary
- ensure the unlock check in `bw-key-init.sh` is case-insensitive

## Testing
- `bash -n bw-key-init.sh`

------
https://chatgpt.com/codex/tasks/task_e_68727e7c1de8832f9e6f69336e9a09b0