### PR TITLE
Fix comment in git install script

### DIFF
--- a/git-install.sh
+++ b/git-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Short and simple jq installer for apt-based systems (Debian/Ubuntu).
+# Short and simple git installer for apt-based systems (Debian/Ubuntu).
 
 if command -v git &> /dev/null; then
   echo "git is already installed."


### PR DESCRIPTION
## Summary
- correct misleading comment in `git-install.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68727e9281a8832f90429b208f240fc2