### PR TITLE
Fix mkrepo configure path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/init.sh)
 
 or
 
-./src/git-init/init.sh
+./init.sh

--- a/mkrepo.py
+++ b/mkrepo.py
@@ -90,7 +90,7 @@ if response.status_code == 201:
 else:
     print('Failed to create repository')
 
-cmd = ['/bin/bash', './git-init/configure.sh', name, email, username, token, repo]
+cmd = ['/bin/bash', './configure.sh', name, email, username, token, repo]
 try:
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()


### PR DESCRIPTION
## Summary
- fix path to `configure.sh` in `mkrepo.py`
- adjust README to use correct init script location

## Testing
- `python3 -m py_compile mkrepo.py init.py`


------
https://chatgpt.com/codex/tasks/task_e_68727cde4e38832fabd7c8720b9b4cd1