### PR TITLE
Fix GitHub spelling

### DIFF
--- a/init.py
+++ b/init.py
@@ -330,7 +330,7 @@ def action_create_repository(token: str, username_from_config: Optional[str]):
     name = global_config.get('user.name') or get_user_input("Enter your Full Name")
     email = global_config.get('user.email') or get_user_input("Enter your Email Address", validate_email)
     # Prefer username from initial config/prompt, fallback to global git config
-    username = username_from_config or global_config.get('user.github.login.name') or get_user_input("Enter your Github Username")
+    username = username_from_config or global_config.get('user.github.login.name') or get_user_input("Enter your GitHub Username")
     repo_name = get_user_input("Enter a unique name for the new repository")
 
     repo_path = Path(repo_name)
@@ -480,7 +480,7 @@ def main():
     github_username = git_config.get('user.github.login.name')
     if not github_username:
         print("\nGitHub username not found in global git config (user.github.login.name).")
-        github_username = get_user_input("Please enter your Github Username")
+        github_username = get_user_input("Please enter your GitHub Username")
 
 
     # 4. Choose Action

--- a/init.sh
+++ b/init.sh
@@ -65,7 +65,7 @@ fi
 gitusername=$(git config --global user.github.login.name)
 
 if [[ -z "$gitusername" ]]; then
-  read -p "Enter your Github username: " gitusername
+  read -p "Enter your GitHub username: " gitusername
   git config --global user.github.login.name "$gitusername"
 fi
 
@@ -81,7 +81,7 @@ fi
 export GITHUB_ACCESS_TOKEN="$pass"
 
 if [[ -z $GITHUB_ACCESS_TOKEN ]]; then
-  echo "Github Access Token not set check environment."
+  echo "GitHub Access Token not set check environment."
   exit 6
 fi
 

--- a/mkrepo.py
+++ b/mkrepo.py
@@ -48,15 +48,15 @@ if not email:
         if validate_email(email):
             break
 
-# Prompt for Github username
+# Prompt for GitHub username
 username = git_config.get('user.github.login.name')
 if not username:
     while True:
-        username = input('Github username: ')
+        username = input('GitHub username: ')
         if username:
             break
         else:
-            print("Github username cannot be empty. Please try again.")
+            print("GitHub username cannot be empty. Please try again.")
 
 # Input and validation loop for repo name
 while True:


### PR DESCRIPTION
## Summary
- update script prompts to spell GitHub correctly
- fix mkrepo.py comments with consistent casing

## Testing
- `grep -R Github -n || true`

------
https://chatgpt.com/codex/tasks/task_e_68729b03e26c832f980675b57703b075