### PR TITLE
Fix bws token retrieval

### DIFF
--- a/bw-key-init.sh
+++ b/bw-key-init.sh
@@ -6,30 +6,52 @@ if [[ -f "config.env" ]]; then
 else
   echo "Warning: config.env file not found." >&2
 fi
-# Secret ID
+
+# Secret IDs from config
 SECRET_ID="$BW_API_KEY_ID"
+BWS_TOKEN_ITEM_ID="$BWS_ACCESS_TOKEN_ID"
 
 # Check if bws is installed.
 if ! command -v bws &> /dev/null; then
-  echo "Error: bws command not found.  Please install the Bitwarden Secrets Manager CLI."
+  echo "Error: bws command not found.  Please install the Bitwarden Secrets Manager CLI." >&2
+  exit 1
+fi
+
+# Check if bw is installed.
+if ! command -v bw &> /dev/null; then
+  echo "Error: bw command not found.  Please install the Bitwarden CLI." >&2
   exit 1
 fi
 
 # Function to ensure BW_SESSION is set and unlocked
 ensure_session() {
-  # If BW_SESSION is unset or expired, login/unlock
   if [[ -z "$BW_SESSION" ]] || ! bw status --session "$BW_SESSION" | grep -iq "unlocked"; then
-    echo "=> Logging into Bitwarden using API key..."
-    # Login with API key, output raw session
-    export BW_SESSION=$(bw login --apikey --raw)
+    echo "=> Logging into Bitwarden..."
+    bw login
+    export BW_SESSION=$(bw unlock --raw)
     if [[ -z "$BW_SESSION" ]]; then
-      echo "Error: Failed to login to Bitwarden." >&2
+      echo "Error: Failed to unlock Bitwarden." >&2
       exit 1
     fi
   fi
 }
 
 ensure_session
+
+# If BWS_ACCESS_TOKEN isn't set, try retrieving it using bw
+if [[ -z "$BWS_ACCESS_TOKEN" ]]; then
+  if [[ -z "$BWS_TOKEN_ITEM_ID" ]]; then
+    echo "Error: BWS_ACCESS_TOKEN is not set and BWS_ACCESS_TOKEN_ID is unknown." >&2
+    exit 1
+  fi
+  echo "=> Retrieving BWS access token from Bitwarden..."
+  BWS_ACCESS_TOKEN=$(bw get password "$BWS_TOKEN_ITEM_ID" --session "$BW_SESSION" 2>/dev/null)
+  if [[ -z "$BWS_ACCESS_TOKEN" ]]; then
+    echo "Error: Failed to retrieve BWS access token." >&2
+    exit 1
+  fi
+  export BWS_ACCESS_TOKEN
+fi
 
 # Retrieve the secret data.
 secret_data=$(bws secret get "$SECRET_ID" 2> /dev/null)

--- a/config.env
+++ b/config.env
@@ -1,2 +1,3 @@
 GH_TOKEN_ID="857d0c2c-cfe0-4e6d-995c-b1690020f8fb" # Replace with your actual GitHub token secret ID
 BW_API_KEY_ID="c368bb97-1837-46d1-ad26-b2aa0103cb25"   # Replace with your actual BW API key secret ID
+BWS_ACCESS_TOKEN_ID="eee4c345-690c-4420-b503-b1c101032641"   # Bitwarden item ID containing the BWS access token


### PR DESCRIPTION
## Summary
- update `bw-key-init.sh` so the Bitwarden API key can be fetched using a normal `bw` session
- add `BWS_ACCESS_TOKEN_ID` to `config.env` so the script knows where to read the bws token

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872acaf7a78832fb70c610dc77ad0a3