### PR TITLE
Remove redundant Bitwarden unlock

### DIFF
--- a/bw-key-init.sh
+++ b/bw-key-init.sh
@@ -77,4 +77,3 @@ if [ -z "$BW_CLIENTID" ] || [ -z "$BW_CLIENTSECRET" ]; then
   #exit 1
 fi
 export BW_CLIENTID BW_CLIENTSECRET
-export BW_SESSION=$(bw unlock --raw)


### PR DESCRIPTION
## Summary
- avoid unlocking Bitwarden twice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872d1657878832fb6539bbc96863fbb