### PR TITLE
Fix: Prevent script failure when no repositories are found

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -115,6 +115,10 @@ if [[ $choice -eq 0 ]]; then
   python3 ${MYINIT}/mkrepo.py
 else
   repos=$(get_repositories "${GITHUB_ACCESS_TOKEN}")
+  if [[ -z "$repos" ]]; then
+    echo "No repositories found." >&2
+    exit 0
+  fi
   IFS=$'\n' read -rd '' -a repo_array <<<"$repos"
   chosen_repo=$(choose "${repo_array[@]}")
   # FIX: Use the access token in the clone URL to prevent password prompts for private repos.


### PR DESCRIPTION
This commit fixes an issue where the `init.sh` script would fail if you chose to clone a repository but had no repositories available on your GitHub account. The script would exit with an error due to `set -euo pipefail` being active.

The fix introduces a check to verify if the `repos` variable is empty after fetching the repository list. If it's empty, the script now prints an informative message and exits gracefully.