### PR TITLE
Fix bw-key unlock failure handling

### DIFF
--- a/bw-key-init.sh
+++ b/bw-key-init.sh
@@ -48,7 +48,9 @@ ensure_session() {
   fi
 }
 
-ensure_session
+if ! ensure_session; then
+  exit 1
+fi
 
 # If BWS_ACCESS_TOKEN isn't set, try retrieving it using bw
 if [[ -z "$BWS_ACCESS_TOKEN" ]]; then


### PR DESCRIPTION
## Summary
- exit the script if unlocking Bitwarden fails

## Testing
- `bash -n bw-key-init.sh`


------
https://chatgpt.com/codex/tasks/task_e_68820e57d798832f9130fc42c9328e18