### PR TITLE
Update README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/init.sh)
 
 or
 
-./bw-key-init.sh 
+# Source the key initialization script so that environment variables such as
+# `BW_SESSION` are exported to your current shell.
+source ./bw-key-init.sh
 ./bws-key-init.sh
 ./init.sh


### PR DESCRIPTION
## Summary
- document that `bw-key-init.sh` must be sourced so environment variables like `BW_SESSION` stay in the current shell

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68820e5a1720832fb75d1beecd3578d9