### PR TITLE
Improve error handling in bw-key-init.sh

### DIFF
--- a/bw-key-init.sh
+++ b/bw-key-init.sh
@@ -35,10 +35,22 @@ ensure_session() {
     echo "=> Unlocking Bitwarden..."
     local session_output
     session_output=$(bw unlock --raw)
+    if [ $? -ne 0 ]; then
+      echo "Error: bw unlock failed." >&2
+      return 1
+    fi
     if echo "$session_output" | grep -q "You are not logged in"; then
       echo "=> Logging into Bitwarden..."
       bw login
+      if [ $? -ne 0 ]; then
+        echo "Error: bw login failed." >&2
+        return 1
+      fi
       session_output=$(bw unlock --raw)
+      if [ $? -ne 0 ]; then
+        echo "Error: bw unlock failed." >&2
+        return 1
+      fi
     fi
     if [[ -z "$session_output" ]] || ! bw status --session "$session_output" | grep -iq "unlocked"; then
       echo "Error: Failed to unlock Bitwarden." >&2


### PR DESCRIPTION
## Summary
- exit on Bitwarden login/unlock failures

## Testing
- `bash -n bw-key-init.sh`
- `shellcheck bw-key-init.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68820e5d9e6c832fbf6917f632b25995