### PR TITLE
Implement automatic bw login

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/init.sh)
 ```
 ./init.sh && source ./bw-key-init.sh
 ```
+
+The `bw-key-init.sh` script will automatically log in to Bitwarden using your API
+key (if available) before unlocking the vault, so no manual `bw login` step is
+required.


### PR DESCRIPTION
## Summary
- auto login to Bitwarden CLI in `bw-key-init.sh`
- mention auto-login feature in README

## Testing
- `bash -n bw-key-init.sh`

------
https://chatgpt.com/codex/tasks/task_e_688238c15dd8832f84691f09f92c0582