### PR TITLE
Remove token from git configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ mkdir -p ~/.config
 cp git-credential-env ~/.config/
 git config --global credential.helper '!~/.config/git-credential-env'
 ```
+The helper expects your token in the `GITHUB_ACCESS_TOKEN` environment variable
+whenever Git needs authentication. Avoid setting `user.github.token` in any git
+configuration; credentials are provided dynamically by the helper.

--- a/mkrepo.sh
+++ b/mkrepo.sh
@@ -85,12 +85,8 @@ fi
 if [[ -z $(git config --global --get user.github.login.name) ]]; then
   git config user.github.login.name "$username"
 fi
-if [[ -z $(git config --global --get user.github.token) ]]; then
-  git config user.github.token "$token"
-fi
 if [[ -z $(git config --global --get credential.helper) ]]; then
-  git config --global credential.helper "!${HOME}/.config/git-credential-env"                                                                                 
-
+  git config --global credential.helper "!${HOME}/.config/git-credential-env"
 fi
 if [[ -z $(git config --global --get push.default) ]]; then
   git config --global push.default simple


### PR DESCRIPTION
## Summary
- document using `GITHUB_ACCESS_TOKEN` with the credential helper
- stop writing the GitHub token to git config in mkrepo.sh

## Testing
- `bash -n mkrepo.sh`
- `bash -n init.sh`
- `python3 -m py_compile init.py`


------
https://chatgpt.com/codex/tasks/task_e_68824e927ebc832fbefa1d5577e3200a