### PR TITLE
Update email detection in init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -156,7 +156,12 @@ main() {
     git config --global user.github.login.name "$gitusername"
   fi
 
-  email=$(git config --global user.email "$gitusername"@users.noreply.github.com)
+  email=$(git config --global user.email || echo "${gitusername}@users.noreply.github.com")
+  if [[ -z "$(git config --global user.email || true)" ]]; then
+    read -p "Enter your email [${gitusername}@users.noreply.github.com]: " email
+    email=${email:-"${gitusername}@users.noreply.github.com"}
+    git config --global user.email "$email"
+  fi
 
   name=$(git config --global user.name || true)
   if [[ -z "$name" ]]; then


### PR DESCRIPTION
## Summary
- fix `init.sh` email setup
- prompt user for Git email when missing

## Testing
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_68826b573f30832fad25655811bccb4a