### PR TITLE
Add shell sourcing tip

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,10 @@ choice=-1
 sourced=0
 [[ ${BASH_SOURCE[0]} != "$0" ]] && sourced=1
 
+if (( ! sourced )); then
+  echo "Tip: run 'source init.sh' (or 'source <(curl -sS .../init.sh)') to keep variables in your shell."
+fi
+
 # Exit or return based on invocation
 safe_exit() {
   local code=${1:-0}


### PR DESCRIPTION
## Summary
- add tip recommending `source init.sh`

## Testing
- `bash init.sh --help` *(fails: `bws` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688274f023a4832fb2da4b56374eaea0