### PR TITLE
Switch jq install to release download

### DIFF
--- a/jq-install.sh
+++ b/jq-install.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
-# Short and simple jq installer for apt-based systems (Debian/Ubuntu).
+set -euo pipefail
 
-if command -v jq &> /dev/null; then
-  echo "jq is already installed."
-  exit 0
+# Configuration
+JQ_VERSION="1.7"
+JQ_FILENAME="jq-linux-amd64"
+DOWNLOAD_URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/${JQ_FILENAME}"
+INSTALL_DIR="${HOME}/.local/bin"
+
+mkdir -p "${INSTALL_DIR}"
+
+# Download the jq binary
+echo "Downloading jq ${JQ_VERSION}..."
+curl -L -o "${INSTALL_DIR}/jq" "${DOWNLOAD_URL}"
+
+# Make it executable
+chmod +x "${INSTALL_DIR}/jq"
+
+# Add INSTALL_DIR to PATH if necessary
+if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+    echo "Adding ${INSTALL_DIR} to PATH in ~/.bashrc"
+    echo "export PATH=\"\$PATH:${INSTALL_DIR}\"" >> "${HOME}/.bashrc"
+    echo "Please run 'source ~/.bashrc' or start a new terminal session"
 fi
 
-echo "Installing jq..."
-sudo apt-get update && sudo apt-get install -y jq
-
-if command -v jq &> /dev/null; then
-  echo "jq installed successfully."
-else
-  echo "jq installation failed."
-  exit 1
-fi
+echo "jq has been installed to ${INSTALL_DIR}/jq"
+echo "Verify installation with: jq --version"


### PR DESCRIPTION
## Summary
- download jq release instead of using apt
- add version variables and PATH checks similar to other installers

## Testing
- `bash -n jq-install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68827cf337f4832fb89f27ad9787b47f