### PR TITLE
Add jq presence check to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,12 @@ git-init
 ## Prerequisites
   1. Curl - unzip - git
 
-### Setup.sh will check for and install these if not found
+### Setup
+Run `./setup.sh` to install the following tools if they are not already available:
 
-  * jq - jquery client
-  
-  * bws - bitwarden sdk (secrets manager)
-  
-  * bw - bitwarden cli
-    
-     ```
-     bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/bws-install.sh)
-     bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/bw-install.sh)
-     bash <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/jq-install.sh)
-     ```
+  * jq - JSON processor
+  * bws - Bitwarden SDK (secrets manager)
+  * bw - Bitwarden CLI
 
 ## Get it and init it
 ### Source the initialization script so that environment variables such as `BW_SESSION` are exported to your current shell.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_prerequisite() {
+  local pkg="$1"
+  if ! command -v "$pkg" >/dev/null 2>&1; then
+    echo "Installing $pkg..."
+    sudo apt-get update && sudo apt-get install -y "$pkg"
+  fi
+}
+
+install_jq() {
+  if command -v jq >/dev/null 2>&1; then
+    echo "jq is already installed."
+  else
+    echo "Installing jq..."
+    sudo apt-get update && sudo apt-get install -y jq
+  fi
+}
+
+install_bw() {
+  if command -v bw >/dev/null 2>&1; then
+    echo "bw is already installed."
+    return
+  fi
+  local BW_VERSION="2025.2.0"
+  local DOWNLOAD_URL="https://github.com/bitwarden/clients/releases/download/cli-v${BW_VERSION}/bw-linux-${BW_VERSION}.zip"
+  local INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+  echo "Downloading bw ${BW_VERSION}..."
+  curl -L "$DOWNLOAD_URL" -o /tmp/bw.zip
+  unzip -o /tmp/bw.zip -d /tmp/bw-temp
+  mv /tmp/bw-temp/bw "$INSTALL_DIR/"
+  chmod +x "$INSTALL_DIR/bw"
+  rm -rf /tmp/bw.zip /tmp/bw-temp
+  echo "bw installed to $INSTALL_DIR/bw"
+}
+
+install_bws() {
+  if command -v bws >/dev/null 2>&1; then
+    echo "bws is already installed."
+    return
+  fi
+  local VERSION="1.0.0"
+  local ARCH="x86_64-unknown-linux-gnu"
+  local FILENAME="bws-${ARCH}-${VERSION}.zip"
+  local DOWNLOAD_URL="https://github.com/bitwarden/sdk-sm/releases/download/bws-v${VERSION}/${FILENAME}"
+  local INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+  echo "Downloading bws ${VERSION}..."
+  curl -L -o "/tmp/${FILENAME}" "$DOWNLOAD_URL"
+  unzip -o "/tmp/${FILENAME}" -d /tmp/bws-temp
+  mv /tmp/bws-temp/bws "$INSTALL_DIR/"
+  chmod +x "$INSTALL_DIR/bws"
+  rm -rf "/tmp/${FILENAME}" /tmp/bws-temp
+  echo "bws installed to $INSTALL_DIR/bws"
+}
+
+ensure_path() {
+  local target="${HOME}/.local/bin"
+  if [[ ":$PATH:" != *":${target}:"* ]]; then
+    echo "Adding ${target} to PATH in ~/.bashrc"
+    echo "export PATH=\"\$PATH:${target}\"" >> "${HOME}/.bashrc"
+  fi
+}
+
+main() {
+  install_prerequisite curl
+  install_prerequisite unzip
+  install_prerequisite git
+
+  install_jq
+  install_bw
+  install_bws
+
+  ensure_path
+
+  echo "Setup complete."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- refine jq install logic in `setup.sh`
- document `setup.sh` usage in README

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68827cf4ff30832f809a78706134da3c