### PR TITLE
Update bws installation to use cargo install

### DIFF
--- a/MInstall-BWS.ps1
+++ b/MInstall-BWS.ps1
@@ -1,30 +1,23 @@
-# Minimal installer for Bitwarden Secrets Manager CLI (bws) v1.0.0 (Windows x86_64)
-# Downloads the zip and drops bws.exe into %LOCALAPPDATA%\Microsoft\WindowsApps
+# Minimal installer for Bitwarden Secrets Manager CLI (bws) via cargo
 
 $ErrorActionPreference = "Stop"
 
-$uri = "https://github.com/bitwarden/sdk-sm/releases/download/bws-v1.0.0/bws-x86_64-pc-windows-msvc-1.0.0.zip"
-$destDir = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps"
-$tmpZip  = Join-Path $env:TEMP "bws.zip"
-$tmpDir  = Join-Path $env:TEMP "bws-extract"
+# Ensure cargo is available
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    throw "cargo is not installed or not in PATH. Please install Rust (e.g. via 'winget install Rustlang.Rustup')."
+}
 
-# Clean temp
-Remove-Item $tmpZip -Force -ErrorAction SilentlyContinue
-Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Path $tmpDir | Out-Null
+Write-Host "Installing bws via cargo..."
+cargo install bws
 
-# Download
-Invoke-WebRequest $uri -OutFile $tmpZip
+# Ensure ~/.cargo/bin is in the PATH for the current session,
+# since cargo typically installs binaries there.
+$cargoBinPath = Join-Path $env:USERPROFILE ".cargo\bin"
 
-# Extract
-Expand-Archive $tmpZip $tmpDir -Force
-
-# Find bws.exe (zip only contains one)
-$bws = Get-ChildItem $tmpDir -Recurse -Filter "bws*.exe" | Select-Object -First 1
-if (-not $bws) { throw "bws.exe not found in archive" }
-
-# Copy to WindowsApps (already on PATH)
-Copy-Item $bws.FullName (Join-Path $destDir "bws.exe") -Force
+if ($env:PATH -notmatch [regex]::Escape($cargoBinPath)) {
+    $env:PATH = "$cargoBinPath;$env:PATH"
+    Write-Host "Added $cargoBinPath to the current session's PATH."
+}
 
 # Verify
-& (Join-Path $destDir "bws.exe") --version
+& bws --version

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A robust PowerShell port suitable for Windows, macOS, and Linux.
 2.  **Git**
 3.  **Bitwarden CLI** (`bw`) - For vault unlocking.
 4.  **Bitwarden Secrets Manager CLI** (`bws`) - For secret retrieval.
+5.  **Rust / Cargo** - For installing `bws`.
 
 ### Installing Prerequisites (Windows)
 
@@ -25,6 +26,7 @@ A robust PowerShell port suitable for Windows, macOS, and Linux.
 winget install pwsh
 winget install Git.Git
 winget install Bitwarden.CLI
+winget install Rustlang.Rustup
 ```
 
 For `bws`, you can use the included helper script:
@@ -93,7 +95,7 @@ The original Bash implementation for Unix-like environments.
 
 
 ## Prerequisites
-  1. Curl - unzip - git
+  1. Curl - unzip - git - cargo (Rust)
 
 ### Setup
 Run `./setup.sh` to install the following tools if they are not already available:

--- a/setup.sh
+++ b/setup.sh
@@ -116,29 +116,23 @@ install_bw() {
 }
 
 install_bws() {
-  local arch="$1"
   if command -v bws >/dev/null 2>&1; then
     echo "bws is already installed."
     return
   fi
-  local VERSION="1.0.0"
-  local bws_arch
-  if [[ "$arch" == "amd64" ]]; then
-    bws_arch="x86_64-unknown-linux-gnu"
-  else
-    bws_arch="aarch64-unknown-linux-gnu"
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo (Rust) is not installed. Please install Rust (e.g., via https://rustup.rs/) to install bws."
+    safe_exit 1
   fi
-  local FILENAME="bws-${bws_arch}-${VERSION}.zip"
-  local DOWNLOAD_URL="https://github.com/bitwarden/sdk-sm/releases/download/bws-v${VERSION}/${FILENAME}"
-  local INSTALL_DIR="${HOME}/.local/bin"
-  mkdir -p "$INSTALL_DIR"
-  echo "Downloading bws ${VERSION}..."
-  curl -L -o "/tmp/${FILENAME}" "$DOWNLOAD_URL"
-  unzip -o "/tmp/${FILENAME}" -d /tmp/bws-temp
-  mv /tmp/bws-temp/bws "$INSTALL_DIR/"
-  chmod +x "$INSTALL_DIR/bws"
-  rm -rf "/tmp/${FILENAME}" /tmp/bws-temp
-  echo "bws installed to $INSTALL_DIR/bws"
+  echo "Installing bws via cargo..."
+  cargo install bws
+
+  # bws is typically installed to ~/.cargo/bin
+  if [[ -f "${HOME}/.cargo/bin/bws" ]]; then
+    echo "bws installed to ${HOME}/.cargo/bin/bws"
+  else
+    echo "bws was installed via cargo but could not be located in ${HOME}/.cargo/bin/bws."
+  fi
 }
 
 ensure_path() {
@@ -146,6 +140,12 @@ ensure_path() {
   if [[ ":$PATH:" != *":${target}:"* ]]; then
     echo "Adding ${target} to PATH in ~/.bashrc"
     echo "export PATH=\"\$PATH:${target}\"" >> "${HOME}/.bashrc"
+  fi
+
+  local cargo_bin="${HOME}/.cargo/bin"
+  if [[ -d "${cargo_bin}" ]] && [[ ":$PATH:" != *":${cargo_bin}:"* ]]; then
+    echo "Adding ${cargo_bin} to PATH in ~/.bashrc"
+    echo "export PATH=\"\$PATH:${cargo_bin}\"" >> "${HOME}/.bashrc"
   fi
 }
 
@@ -171,7 +171,7 @@ main() {
 
   install_jq "$arch"
   install_bw "$arch"
-  install_bws "$arch"
+  install_bws
 
   ensure_path
 


### PR DESCRIPTION
Update bws installation to use cargo install

- Updated `README.md` to include Rust/Cargo as a prerequisite.
- Modified `MInstall-BWS.ps1` to install `bws` via `cargo install bws` instead of downloading the zip file.
- Modified `setup.sh` to install `bws` via `cargo install bws` instead of downloading the zip file, and updated the path adding logic to include `~/.cargo/bin`.

---
*PR created automatically by Jules for task [10934775353942936499](https://jules.google.com/task/10934775353942936499) started by @redog*