### PR TITLE
Add config-management functions and bootstrap on missing config

### DIFF
--- a/APIKeys/APIKeys.psd1
+++ b/APIKeys/APIKeys.psd1
@@ -5,6 +5,11 @@
     Author            = 'Eric Ortego'
     Description       = 'Loads API keys from Bitwarden Secrets Manager into environment variables.'
     PowerShellVersion = '7.0'
-    FunctionsToExport = @('Get-BwsSecretValue','Get-APIKeyMap','Set-AllAPIKeys','Clear-APIKeyEnv','Set-APIKeysConfig','Import-APIKeysConfig','Connect-Bitwarden')
+    FunctionsToExport = @(
+        'Get-BwsSecretValue','Get-APIKeyMap','Set-AllAPIKeys','Clear-APIKeyEnv',
+        'Set-APIKeysConfig','Import-APIKeysConfig','Connect-Bitwarden',
+        'Show-APIKeysConfig','Save-APIKeysConfig','Get-APIKeysConfigPath',
+        'Initialize-APIKeysConfigFile','Add-APIKey','Remove-APIKey','Set-APIKeysConfigField'
+    )
     AliasesToExport   = @('load_keys')
 }

--- a/APIKeys/APIKeys.psm1
+++ b/APIKeys/APIKeys.psm1
@@ -20,6 +20,10 @@ $script:BwsTokenItem = 'Bitwarden Secrets Manager Service Account'
 #     * literal   => set as-is
 $script:KeyMap = @()
 
+# Path the active config was loaded from / will be saved to. Set by
+# Import-APIKeysConfig and the *-APIKeysConfig*/Add-APIKey/Remove-APIKey helpers.
+$script:ConfigPath = $null
+
 function Set-APIKeysConfig {
     <#
     .SYNOPSIS
@@ -105,6 +109,144 @@ function Import-APIKeysConfig {
     if ($config.ContainsKey('KeyMap'))       { $params['KeyMap']       = $config.KeyMap }
 
     Set-APIKeysConfig @params
+    $script:ConfigPath = (Resolve-Path $Path).Path
+}
+
+function Get-APIKeysConfigPath {
+    [CmdletBinding()]
+    param()
+    $script:ConfigPath
+}
+
+function Show-APIKeysConfig {
+    <#
+    .SYNOPSIS
+        Returns the current in-memory config as a structured object.
+    #>
+    [CmdletBinding()]
+    param()
+    [pscustomobject]@{
+        Path         = $script:ConfigPath
+        BwsCliPath   = $script:BwsCliPath
+        BwsTokenItem = $script:BwsTokenItem
+        KeyMap       = $script:KeyMap
+    }
+}
+
+function Save-APIKeysConfig {
+    <#
+    .SYNOPSIS
+        Persists the in-memory config to a JSON file.
+    .PARAMETER Path
+        Override the destination path. Defaults to the previously loaded
+        path, or ~/.git-init.json if none is set.
+    #>
+    [CmdletBinding()]
+    param([string]$Path)
+
+    if (-not $Path) { $Path = $script:ConfigPath }
+    if (-not $Path) { $Path = Join-Path $HOME '.git-init.json' }
+
+    $payload = [ordered]@{
+        BwsCliPath   = $script:BwsCliPath
+        BwsTokenItem = $script:BwsTokenItem
+        KeyMap       = @($script:KeyMap)
+    }
+
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $json = $payload | ConvertTo-Json -Depth 10
+    Set-Content -Path $Path -Value $json -Encoding utf8
+    $script:ConfigPath = (Resolve-Path $Path).Path
+    Write-Host "Wrote $($script:ConfigPath)"
+}
+
+function Initialize-APIKeysConfigFile {
+    <#
+    .SYNOPSIS
+        Create a new git-init config file with empty KeyMap.
+    .PARAMETER Path
+        Where to write the new file. Defaults to ~/.git-init.json.
+    .PARAMETER BwsTokenItem
+        Name or UUID of the bw vault item holding the BWS access token.
+    .PARAMETER BwsCliPath
+        Path to the bws executable.
+    .PARAMETER Force
+        Overwrite an existing config file.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Path,
+        [string]$BwsTokenItem = 'Bitwarden Secrets Manager Service Account',
+        [string]$BwsCliPath = 'bws',
+        [switch]$Force
+    )
+    if (-not $Path) { $Path = Join-Path $HOME '.git-init.json' }
+    if ((Test-Path $Path) -and -not $Force) {
+        Write-Warning "Config already exists at $Path. Pass -Force to overwrite, or use Add-APIKey/Set-APIKeysConfigField to modify."
+        return
+    }
+    Set-APIKeysConfig -BwsCliPath $BwsCliPath -BwsTokenItem $BwsTokenItem -KeyMap @()
+    Save-APIKeysConfig -Path $Path
+}
+
+function Add-APIKey {
+    <#
+    .SYNOPSIS
+        Add or update a KeyMap entry and persist to the active config file.
+    .PARAMETER Name
+        Friendly name (e.g. "GitHub").
+    .PARAMETER SecretId
+        UUID of the secret in Bitwarden Secrets Manager.
+    .PARAMETER Env
+        Hashtable mapping env-var names to values. Use the literal '$secret'
+        to inject the secret value, or any other string to set as-is.
+    .PARAMETER Path
+        Override save path. Defaults to the loaded path or ~/.git-init.json.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]    $Name,
+        [Parameter(Mandatory)] [string]    $SecretId,
+        [Parameter(Mandatory)] [hashtable] $Env,
+        [string]                            $Path
+    )
+    $existing = @($script:KeyMap | Where-Object { $_.Name -ne $Name })
+    $script:KeyMap = $existing + @(@{ Name = $Name; SecretId = $SecretId; Env = $Env })
+    Save-APIKeysConfig -Path $Path
+    Write-Host "Added/updated key '$Name'."
+}
+
+function Remove-APIKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [string]                          $Path
+    )
+    $script:KeyMap = @($script:KeyMap | Where-Object { $_.Name -ne $Name })
+    Save-APIKeysConfig -Path $Path
+    Write-Host "Removed key '$Name'."
+}
+
+function Set-APIKeysConfigField {
+    <#
+    .SYNOPSIS
+        Update a top-level config field and persist.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [ValidateSet('BwsCliPath','BwsTokenItem')]
+        [string] $Field,
+        [Parameter(Mandatory)] [string] $Value,
+        [string] $Path
+    )
+    if ($Field -eq 'BwsCliPath')   { $script:BwsCliPath   = $Value }
+    if ($Field -eq 'BwsTokenItem') { $script:BwsTokenItem = $Value }
+    Save-APIKeysConfig -Path $Path
+    Write-Host "Set $Field = $Value"
 }
 
 # endregion
@@ -343,4 +485,9 @@ function Clear-APIKeyEnv {
 # endregion
 
 Set-Alias -Name load_keys -Value Set-AllAPIKeys
-Export-ModuleMember -Function Get-BwsSecretValue, Get-APIKeyMap, Set-AllAPIKeys, Clear-APIKeyEnv, Set-APIKeysConfig, Import-APIKeysConfig, Connect-Bitwarden -Alias load_keys
+Export-ModuleMember -Function `
+    Get-BwsSecretValue, Get-APIKeyMap, Set-AllAPIKeys, Clear-APIKeyEnv, `
+    Set-APIKeysConfig, Import-APIKeysConfig, Connect-Bitwarden, `
+    Show-APIKeysConfig, Save-APIKeysConfig, Get-APIKeysConfigPath, `
+    Initialize-APIKeysConfigFile, Add-APIKey, Remove-APIKey, Set-APIKeysConfigField `
+    -Alias load_keys

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Both implementations read the same configuration file. Lookup order:
 3.  `<repo>/config.json`
 4.  `<repo>/config.psd1` or `~/.git-init.psd1` (PowerShell legacy, still supported)
 
-Copy `config.sample.json` to `config.json` and fill in your IDs:
+**You don't need to author this file by hand.** Run `init.sh` or `init.ps1`
+with no existing config and it will prompt you for the BWS token-item and your
+GitHub PAT secret UUID, then write `~/.git-init.json` for you. From there you
+manage the file with shell/PS functions — never with a text editor.
+
+Copy `config.sample.json` to `config.json` only if you prefer a static template:
 
 ```json
 {
@@ -92,6 +97,12 @@ Exposed cmdlets after sourcing:
 | `Update-VaultAPIKey`         | Update a secret in BWS and reload it locally.        |
 | `Get-APIKeyMap`              | Print the loaded key map.                            |
 | `Connect-Bitwarden`          | Ensure `bw` is logged-in and unlocked.               |
+| `Initialize-APIKeysConfigFile -Path -BwsTokenItem -BwsCliPath` | Create a new config file. |
+| `Add-APIKey -Name -SecretId -Env @{...}` | Add/update a KeyMap entry and persist.    |
+| `Remove-APIKey -Name`        | Drop a KeyMap entry and persist.                     |
+| `Set-APIKeysConfigField -Field -Value` | Set `BwsCliPath` / `BwsTokenItem`.         |
+| `Show-APIKeysConfig`         | Dump current config (path + map).                    |
+| `Save-APIKeysConfig [-Path]` | Persist current in-memory config.                    |
 | `Get-GHUser` / `Get-GHRepositories` / `New-GHRepository` | GitHub helpers. |
 
 ---
@@ -130,11 +141,30 @@ Exposed functions after sourcing:
 | `gi_update_key <name> [value]`    | Update a secret in BWS and reload it locally.        |
 | `gi_list_keys`                    | List `Name`, `SecretId`, env vars per entry.         |
 | `gi_get_secret <secret-id>`       | Fetch a single value from BWS.                       |
+| `gi_config_init [path]`           | Interactively create a new config file.              |
+| `gi_config_show`                  | Pretty-print the current config + path.              |
+| `gi_config_set <field> <value>`   | Update `BwsCliPath` or `BwsTokenItem` and persist.   |
+| `gi_config_add_key [name] [id] [VAR\|VAR=value] [...]` | Add/update a KeyMap entry. Prompts for missing args. |
+| `gi_config_remove_key <name>`     | Drop a KeyMap entry by name.                         |
 | `gi_connect_bitwarden`            | Ensure `bw` is logged-in and unlocked.               |
 | `gi_get_bws_token`                | Bootstrap `BWS_ACCESS_TOKEN` from the bw vault item. |
 | `gi_gh_user` / `gi_gh_repos` / `gi_gh_new_repo <name>` | GitHub helpers.                |
 | `gi_init_local_repo <repo> <gh-user> <full-name> <email>` | Local init + first push. |
 | `gi_menu`                         | Interactive create/clone menu.                       |
+
+Examples:
+
+```bash
+# Add a key. Default value '$secret' gets replaced with the BWS lookup.
+gi_config_add_key OpenAI fbe0690e-fb43-4e91-b49c-b0b50039847a OPENAI_API_KEY
+
+# One secret, multiple env vars (one with a literal flag).
+gi_config_add_key LangSmith ad3f662b-9c78-4d22-9e15-b2c70147eabc \
+    LANGCHAIN_API_KEY LANGSMITH_API_KEY LANGCHAIN_TRACING_V2=true
+
+gi_config_set BwsTokenItem 'My Token Item'
+gi_config_remove_key OpenAI
+```
 
 ### Sourcing safety
 

--- a/init.ps1
+++ b/init.ps1
@@ -22,6 +22,28 @@ $configCandidates = @(
 
 $configPath = if ($configCandidates) { $configCandidates[0] } else { $null }
 
+if (-not $configPath) {
+    Write-Host "No git-init config found. Let's set one up." -ForegroundColor Cyan
+    $defaultItem = 'Bitwarden Secrets Manager Service Account'
+    $itemInput = Read-Host "Bitwarden vault item (name or UUID) holding BWS access token [$defaultItem]"
+    if ([string]::IsNullOrWhiteSpace($itemInput)) { $itemInput = $defaultItem }
+
+    $cliInput = Read-Host "BWS CLI path [bws]"
+    if ([string]::IsNullOrWhiteSpace($cliInput)) { $cliInput = 'bws' }
+
+    Write-Host "Your KeyMap needs at least a 'GitHub' entry mapping to GITHUB_ACCESS_TOKEN."
+    Write-Host "List BWS secrets with: bws secret list"
+    $ghId = Read-Host 'GitHub PAT secret UUID in BWS'
+
+    $defaultPath = Join-Path $HOME '.git-init.json'
+    $pathInput = Read-Host "Save config to [$defaultPath]"
+    if ([string]::IsNullOrWhiteSpace($pathInput)) { $pathInput = $defaultPath }
+
+    Initialize-APIKeysConfigFile -Path $pathInput -BwsTokenItem $itemInput -BwsCliPath $cliInput
+    Add-APIKey -Name 'GitHub' -SecretId $ghId -Env @{ GITHUB_ACCESS_TOKEN = '$secret' } -Path $pathInput
+    $configPath = $pathInput
+}
+
 if ($configPath) {
     Write-Host "Loading configuration from $configPath..."
     Import-APIKeysConfig -Path $configPath
@@ -59,7 +81,7 @@ if ($configPath) {
     }
 }
 else {
-    Write-Warning "Configuration file not found. Tried: \$env:GIT_INIT_CONFIG, $ScriptDir/config.json, $HOME/.git-init.json, $ScriptDir/config.psd1, $HOME/.git-init.psd1. API keys will not be loaded."
+    Write-Warning "Configuration file not loaded. API keys will not be available."
 }
 
 # Verify GitHub Token

--- a/init.sh
+++ b/init.sh
@@ -82,6 +82,180 @@ gi_config_get() {
   echo "$_GI_CONFIG_JSON" | jq -r "$1"
 }
 
+gi_config_default_path() {
+  if [[ -n "${GIT_INIT_CONFIG:-}" ]]; then
+    echo "${GIT_INIT_CONFIG}"
+  else
+    echo "$HOME/.git-init.json"
+  fi
+}
+
+# Persist the in-memory config JSON to disk.
+# Usage: gi_config_write <json-content> [path]
+# If <path> is omitted, uses $_GI_CONFIG_PATH or gi_config_default_path.
+# Note: takes content as an argument (not stdin) so callers can use it
+# without a pipeline, which would put the function in a subshell and
+# lose the _GI_CONFIG_* assignments.
+gi_config_write() {
+  local content="${1:-}"
+  local path="${2:-${_GI_CONFIG_PATH:-$(gi_config_default_path)}}"
+  [[ -n "$content" ]] || { echo "gi_config_write: content required" >&2; return 1; }
+  if ! printf '%s' "$content" | jq empty 2>/dev/null; then
+    echo "Refusing to write invalid JSON to $path." >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$path")"
+  local tmp
+  tmp=$(mktemp "$path.XXXXXX") || return 1
+  printf '%s\n' "$content" > "$tmp"
+  chmod 600 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$path"
+  _GI_CONFIG_PATH="$path"
+  _GI_CONFIG_JSON="$content"
+  echo "Wrote $path" >&2
+}
+
+gi_config_show() {
+  if [[ -z "$_GI_CONFIG_JSON" ]]; then
+    gi_load_config 2>/dev/null || { echo "No config loaded." >&2; return 1; }
+  fi
+  echo "Path: $_GI_CONFIG_PATH" >&2
+  echo "$_GI_CONFIG_JSON" | jq .
+}
+
+gi_config_init() {
+  # Interactive bootstrap. Optional arg: target path.
+  local target="${1:-}"
+  [[ -z "$target" ]] && target=$(gi_config_default_path)
+
+  if [[ -f "$target" ]]; then
+    echo "Config already exists at $target. Use gi_config_add_key / gi_config_set to modify it." >&2
+    return 1
+  fi
+
+  echo "Setting up a new git-init configuration at $target" >&2
+
+  local item cli gh_id
+  read -rp "Bitwarden vault item (name or UUID) holding the BWS access token [Bitwarden Secrets Manager Service Account]: " item
+  item=${item:-Bitwarden Secrets Manager Service Account}
+
+  read -rp "BWS CLI executable [bws]: " cli
+  cli=${cli:-bws}
+
+  echo "" >&2
+  echo "Your KeyMap needs at least a 'GitHub' entry mapping to GITHUB_ACCESS_TOKEN." >&2
+  echo "List BWS secrets with: bws secret list" >&2
+  read -rp "GitHub PAT secret UUID in BWS: " gh_id
+
+  local config
+  config=$(jq -n \
+    --arg item "$item" \
+    --arg cli  "$cli" \
+    --arg gh   "$gh_id" \
+    '{
+      BwsCliPath:   $cli,
+      BwsTokenItem: $item,
+      KeyMap: [
+        { Name: "GitHub", SecretId: $gh, Env: { GITHUB_ACCESS_TOKEN: "$secret" } }
+      ]
+    }')
+  gi_config_write "$config" "$target"
+}
+
+gi_config_set() {
+  # gi_config_set <field> <value>  (field: BwsCliPath | BwsTokenItem)
+  local field="${1:-}" value="${2:-}"
+  [[ -n "$field" && -n "$value" ]] || { echo "Usage: gi_config_set <BwsCliPath|BwsTokenItem> <value>" >&2; return 1; }
+  case "$field" in
+    BwsCliPath|BwsTokenItem) ;;
+    *) echo "Unknown field '$field'. Valid: BwsCliPath, BwsTokenItem." >&2; return 1 ;;
+  esac
+
+  if [[ -z "$_GI_CONFIG_JSON" ]]; then
+    gi_load_config 2>/dev/null \
+      || _GI_CONFIG_JSON=$(jq -n '{BwsCliPath:"bws", BwsTokenItem:"Bitwarden Secrets Manager Service Account", KeyMap: []}')
+  fi
+  local updated
+  updated=$(printf '%s' "$_GI_CONFIG_JSON" | jq --arg f "$field" --arg v "$value" '.[$f] = $v')
+  gi_config_write "$updated"
+  echo "Set $field = $value" >&2
+}
+
+gi_config_add_key() {
+  # gi_config_add_key [name] [secret-id] [env-var | env-var=value] [...]
+  # Prompts for any missing required argument. If only the env name is given,
+  # the value defaults to "$secret" (which gets replaced with the BWS value at load time).
+  local name="${1:-}" secret_id="${2:-}"
+  [[ $# -ge 1 ]] && shift
+  [[ $# -ge 1 ]] && shift
+
+  if [[ -z "$name" ]]; then
+    read -rp "Key name (e.g. GitHub, OpenAI): " name
+  fi
+  [[ -n "$name" ]] || { echo "Name is required." >&2; return 1; }
+
+  if [[ -z "$secret_id" ]]; then
+    read -rp "BWS secret UUID for '$name': " secret_id
+  fi
+  [[ -n "$secret_id" ]] || { echo "SecretId is required." >&2; return 1; }
+
+  local env_specs=("$@")
+  if [[ ${#env_specs[@]} -eq 0 ]]; then
+    local default_var
+    case "$name" in
+      [Gg]it[Hh]ub)        default_var="GITHUB_ACCESS_TOKEN" ;;
+      [Oo]pen[Aa][Ii])     default_var="OPENAI_API_KEY" ;;
+      [Aa]nthropic)        default_var="ANTHROPIC_API_KEY" ;;
+      *)                   default_var="$(echo "$name" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9' '_')_API_KEY" ;;
+    esac
+    local var
+    read -rp "Environment variable name [$default_var]: " var
+    env_specs=("${var:-$default_var}")
+  fi
+
+  local env_json='{}' pair key val
+  for pair in "${env_specs[@]}"; do
+    if [[ "$pair" == *=* ]]; then
+      key="${pair%%=*}"
+      val="${pair#*=}"
+    else
+      key="$pair"
+      val='$secret'
+    fi
+    env_json=$(echo "$env_json" | jq --arg k "$key" --arg v "$val" '. + {($k): $v}')
+  done
+
+  if [[ -z "$_GI_CONFIG_JSON" ]]; then
+    gi_load_config 2>/dev/null \
+      || _GI_CONFIG_JSON=$(jq -n '{BwsCliPath:"bws", BwsTokenItem:"Bitwarden Secrets Manager Service Account", KeyMap: []}')
+  fi
+
+  local updated
+  updated=$(printf '%s' "$_GI_CONFIG_JSON" | jq \
+    --arg name "$name" \
+    --arg sid  "$secret_id" \
+    --argjson env "$env_json" '
+      .KeyMap = (
+        (.KeyMap // []) | map(select(.Name != $name)) +
+        [{ Name: $name, SecretId: $sid, Env: $env }]
+      )
+    ')
+  gi_config_write "$updated"
+  echo "Added/updated '$name' in $_GI_CONFIG_PATH." >&2
+}
+
+gi_config_remove_key() {
+  local name="${1:-}"
+  [[ -n "$name" ]] || { echo "Usage: gi_config_remove_key <name>" >&2; return 1; }
+  [[ -n "$_GI_CONFIG_JSON" ]] || gi_load_config || return 1
+
+  local updated
+  updated=$(printf '%s' "$_GI_CONFIG_JSON" \
+    | jq --arg n "$name" '.KeyMap = (.KeyMap | map(select(.Name != $n)))')
+  gi_config_write "$updated"
+  echo "Removed '$name'." >&2
+}
+
 #==============================================================================
 # bitwarden / bws bootstrap
 #==============================================================================
@@ -507,18 +681,29 @@ Options:
   -h, --help      Show this help.
 
 Functions exposed when sourced:
-  gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet]
-  gi_clear_keys [--all]
-  gi_update_key <name> [new-value]
-  gi_list_keys
-  gi_get_secret <secret-id>
-  gi_connect_bitwarden
-  gi_get_bws_token
-  gi_gh_user
-  gi_gh_repos
-  gi_gh_new_repo <name>
-  gi_init_local_repo <repo> <gh-username> <full-name> <email>
-  gi_menu
+
+  Key loading / management:
+    gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet]
+    gi_clear_keys [--all]
+    gi_update_key <name> [new-value]
+    gi_list_keys
+    gi_get_secret <secret-id>
+
+  Config management (no JSON editing required):
+    gi_config_init [path]
+    gi_config_show
+    gi_config_set <BwsCliPath|BwsTokenItem> <value>
+    gi_config_add_key [name] [secret-id] [VAR | VAR=value] [...]
+    gi_config_remove_key <name>
+
+  Bitwarden / GitHub helpers:
+    gi_connect_bitwarden
+    gi_get_bws_token
+    gi_gh_user
+    gi_gh_repos
+    gi_gh_new_repo <name>
+    gi_init_local_repo <repo> <gh-username> <full-name> <email>
+    gi_menu
 EOF
 }
 
@@ -541,7 +726,12 @@ _gi_main_body() {
     command -v "$cmd" &>/dev/null || { echo "Error: $cmd command not found." >&2; return 1; }
   done
 
-  gi_load_config || return 1
+  if ! gi_load_config 2>/dev/null; then
+    echo "No git-init config found at \$GIT_INIT_CONFIG / ~/.git-init.json / $(gi_script_dir)/config.json."
+    echo "Let's set one up."
+    gi_config_init || return 1
+    gi_load_config || return 1
+  fi
   echo "Loaded configuration from $_GI_CONFIG_PATH."
 
   local should_load=0
@@ -578,13 +768,21 @@ _gi_main_body() {
 }
 
 # Wrapper that always restores caller's shell options, even on failure paths.
+# Note: don't use $(set +o) — bash clears -e inside command-substitution subshells
+# (non-POSIX behavior), which would make us "restore" errexit-off when the caller
+# actually had errexit on. Inspect $- and shopt -qo directly instead.
 _gi_main() {
-  local _saved rc=0
-  _saved="$(set +o)"
+  local _e=0 _u=0 _p=0 rc=0
+  [[ $- == *e* ]] && _e=1
+  [[ $- == *u* ]] && _u=1
+  shopt -qo pipefail 2>/dev/null && _p=1
+
   _gi_main_body "$@" || rc=$?
-  # Defensive: explicitly clear strict opts before eval, in case _saved is empty.
+
   set +e +u +o pipefail 2>/dev/null || true
-  eval "$_saved"
+  (( _e )) && set -e
+  (( _u )) && set -u
+  (( _p )) && set -o pipefail
   return "$rc"
 }
 


### PR DESCRIPTION
Users no longer hand-edit JSON. Both implementations now expose a matching surface for managing the file from the shell, and the main entry points prompt for a missing config and create one automatically.

Bash (init.sh):
- gi_config_init [path] — interactive bootstrap (prompts for BwsTokenItem, BwsCliPath, and a GitHub PAT secret UUID; writes ~/.git-init.json).
- gi_config_show / gi_config_set / gi_config_add_key / gi_config_remove_key for round-trip edits without touching JSON.
- gi_config_write now takes content as an argument (not stdin) so it doesn't run in a pipeline subshell that swallows the _GI_CONFIG_* variable updates.
- _gi_main_body bootstraps via gi_config_init when load_config fails.

Strict-opts wrapper rewrite:
- $(set +o) silently captures errexit-off because bash clears -e in command-substitution subshells (non-POSIX behavior). Switched to inspecting $- and shopt -qo pipefail directly. Verified preservation in both strict-on and strict-off callers, on the failure path.

PowerShell (APIKeys/APIKeys.psm1):
- Initialize-APIKeysConfigFile, Add-APIKey, Remove-APIKey, Set-APIKeysConfigField, Show-APIKeysConfig, Save-APIKeysConfig, Get-APIKeysConfigPath. Module tracks $script:ConfigPath so saves go back to the file you loaded from.
- init.ps1 prompts for the same fields when no config is found and writes a fresh ~/.git-init.json before continuing.

README updated with the new commands + examples.

https://claude.ai/code/session_01TV1ctMXYw1MLQDTfaGVY35