### PR TITLE
Fix PS config-path detection picking up "/" + harden config parse

### DIFF
--- a/APIKeys/APIKeys.psm1
+++ b/APIKeys/APIKeys.psm1
@@ -72,16 +72,29 @@ function Import-APIKeysConfig {
         [string]$Path
     )
 
-    if (-not (Test-Path $Path)) {
-        throw "Configuration file not found: $Path"
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Configuration file not found (or not a file): $Path"
     }
 
     $config = $null
-    if ($Path -match '\.json$') {
-        $config = Get-Content -Raw -Path $Path | ConvertFrom-Json -AsHashtable
+    try {
+        if ($Path -match '\.json$') {
+            $raw = Get-Content -Raw -LiteralPath $Path
+            if ([string]::IsNullOrWhiteSpace($raw)) {
+                throw "Config file is empty: $Path"
+            }
+            $config = $raw | ConvertFrom-Json -AsHashtable
+        }
+        else {
+            $config = Import-PowerShellDataFile -LiteralPath $Path
+        }
     }
-    else {
-        $config = Import-PowerShellDataFile -Path $Path
+    catch {
+        throw "Failed to parse config file '$Path': $($_.Exception.Message)"
+    }
+
+    if ($null -eq $config -or -not ($config -is [System.Collections.IDictionary])) {
+        throw "Config file '$Path' did not produce an object/hashtable."
     }
 
     # Normalize KeyMap entries so each entry's Env is a hashtable. ConvertFrom-Json

--- a/init.ps1
+++ b/init.ps1
@@ -4,7 +4,14 @@ param(
     [switch]$Reload
 )
 
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+
+# Resolve user home robustly: $HOME can be unset (or wrong) on some shell
+# setups, which made the lookup below pick up "/" as a candidate.
+$UserHome = if ($HOME -and (Test-Path -LiteralPath $HOME -PathType Container)) { $HOME }
+            elseif ($env:HOME -and (Test-Path -LiteralPath $env:HOME -PathType Container)) { $env:HOME }
+            elseif ($IsWindows) { $env:USERPROFILE }
+            else { [Environment]::GetFolderPath('UserProfile') }
 
 # Import Modules
 Import-Module (Join-Path $ScriptDir "APIKeys") -Force
@@ -12,15 +19,22 @@ Import-Module (Join-Path $ScriptDir "GitInit") -Force
 Import-Module (Join-Path $ScriptDir "APIKeys" "KeyRotation") -Force
 
 # Load configuration. JSON is canonical (shared with init.sh); .psd1 kept for back-compat.
-$configCandidates = @(
+$configPath = $null
+foreach ($candidate in @(
     $env:GIT_INIT_CONFIG,
     (Join-Path $ScriptDir 'config.json'),
-    (Join-Path $HOME    '.git-init.json'),
+    (Join-Path $UserHome  '.git-init.json'),
     (Join-Path $ScriptDir 'config.psd1'),
-    (Join-Path $HOME    '.git-init.psd1')
-) | Where-Object { $_ -and (Test-Path $_) }
-
-$configPath = if ($configCandidates) { $configCandidates[0] } else { $null }
+    (Join-Path $UserHome  '.git-init.psd1')
+)) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+    # -PathType Leaf is critical: without it Test-Path matches directories,
+    # so a stray "/" candidate would pass and Import-PowerShellDataFile would
+    # then fail with "cannot find path '/'".
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) { continue }
+    $configPath = $candidate
+    break
+}
 
 if (-not $configPath) {
     Write-Host "No git-init config found. Let's set one up." -ForegroundColor Cyan
@@ -33,9 +47,17 @@ if (-not $configPath) {
 
     Write-Host "Your KeyMap needs at least a 'GitHub' entry mapping to GITHUB_ACCESS_TOKEN."
     Write-Host "List BWS secrets with: bws secret list"
-    $ghId = Read-Host 'GitHub PAT secret UUID in BWS'
+    $ghId = Read-Host 'GitHub PAT secret UUID in BWS (8-4-4-4-12 hex)'
+    if ([string]::IsNullOrWhiteSpace($ghId)) {
+        Write-Error "GitHub secret UUID is required. Aborting."
+        return
+    }
+    if ($ghId -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+        Write-Error "'$ghId' is not a valid UUID (expected 8-4-4-4-12 hex chars). Aborting."
+        return
+    }
 
-    $defaultPath = Join-Path $HOME '.git-init.json'
+    $defaultPath = Join-Path $UserHome '.git-init.json'
     $pathInput = Read-Host "Save config to [$defaultPath]"
     if ([string]::IsNullOrWhiteSpace($pathInput)) { $pathInput = $defaultPath }
 
@@ -46,7 +68,13 @@ if (-not $configPath) {
 
 if ($configPath) {
     Write-Host "Loading configuration from $configPath..."
-    Import-APIKeysConfig -Path $configPath
+    try {
+        Import-APIKeysConfig -Path $configPath
+    }
+    catch {
+        Write-Error "Failed to load configuration: $($_.Exception.Message)"
+        return
+    }
 
     # Load Keys (this sets env vars like GITHUB_ACCESS_TOKEN)
     $shouldLoadKeys = $Reload


### PR DESCRIPTION
User reported: ". ./src/git-init/init.ps1" with a valid ~/.git-init.json loaded `/` as the config path, so Import-PowerShellDataFile bailed and four `null-valued expression` errors followed because Import-APIKeysConfig called .ContainsKey() on the resulting null hashtable.

Two underlying causes:

1. The candidate filter used `Test-Path $_` without -PathType Leaf, so it accepted directories (including `/`). Combined with $HOME or $ScriptDir being unexpectedly empty/`/` in the user's shell, this produced a single-character path that passed the filter.

2. Import-APIKeysConfig didn't validate the parsed result, so a failed parse silently returned $null and the caller marched on with an empty KeyMap (the WARNING + "GITHUB_ACCESS_TOKEN is not set" tail).

Fixes:

- init.ps1: switch to $PSScriptRoot, resolve $UserHome with three fallbacks (PS $HOME -> $env:HOME -> [Environment]::GetFolderPath), filter candidates with `Test-Path -LiteralPath -PathType Leaf` and IsNullOrWhiteSpace.
- init.ps1: wrap Import-APIKeysConfig in try/catch and `return` cleanly on failure so we don't continue into the menu.
- init.ps1: validate the GitHub UUID at bootstrap (matches the bash side).
- APIKeys.psm1: Import-APIKeysConfig now uses -LiteralPath, refuses an empty file, wraps the parse in try/catch with a clear error, and asserts the result is an IDictionary before touching .ContainsKey().

https://claude.ai/code/session_01TV1ctMXYw1MLQDTfaGVY35