### PR TITLE
Fix double master password prompt on first run

### DIFF
--- a/APIKeys/APIKeys.psm1
+++ b/APIKeys/APIKeys.psm1
@@ -293,13 +293,17 @@ function Connect-Bitwarden {
         # Check for Environment Variables for Headless/API Login
         if ($env:BW_CLIENTID -and $env:BW_CLIENTSECRET) {
             Write-Host "🤖 Logging in with API Key..." -ForegroundColor Cyan
-            bw login --apikey
+            $session = bw login --apikey --raw
             if ($LASTEXITCODE -ne 0) { throw "API Key login failed." }
         }
         else {
             Write-Host "👤 Logging in interactively..." -ForegroundColor Cyan
-            bw login
+            $session = bw login --raw
             if ($LASTEXITCODE -ne 0) { throw "Interactive login failed." }
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($session)) {
+            $env:BW_SESSION = $session.Trim()
         }
 
         # Refresh status after login attempt

--- a/init.sh
+++ b/init.sh
@@ -325,14 +325,16 @@ gi_connect_bitwarden() {
   status=$(bw status 2>/dev/null | jq -r '.status' 2>/dev/null || echo "")
 
   if [[ "$status" == "unauthenticated" || -z "$status" ]]; then
+    local session
     if [[ -n "${BW_CLIENTID:-}" && -n "${BW_CLIENTSECRET:-}" ]]; then
       echo "🤖 Logging in to Bitwarden CLI with API key..."
-      BW_CLIENTID="$BW_CLIENTID" BW_CLIENTSECRET="$BW_CLIENTSECRET" bw login --apikey \
+      session=$(BW_CLIENTID="$BW_CLIENTID" BW_CLIENTSECRET="$BW_CLIENTSECRET" bw login --apikey --raw) \
         || { echo "API key login failed." >&2; return 1; }
     else
       echo "👤 Logging in to Bitwarden CLI..."
-      bw login || { echo "Interactive login failed." >&2; return 1; }
+      session=$(bw login --raw) || { echo "Interactive login failed." >&2; return 1; }
     fi
+    export BW_SESSION="$session"
     status=$(bw status 2>/dev/null | jq -r '.status' 2>/dev/null || echo "")
   fi
 


### PR DESCRIPTION
Fix double master password prompt on first run

When authenticating via `bw login`, the Bitwarden CLI does not
automatically set `BW_SESSION`. Previously, `init.sh` and `APIKeys.psm1`
ran `bw login`, left `BW_SESSION` empty, and then noticed the vault
was "locked" (since there was no session variable), triggering a second
prompt for the master password via `bw unlock`.

This change passes the `--raw` flag to `bw login` so that the
session key is immediately captured and exported as `BW_SESSION`. Now,
the vault evaluates as "unlocked" immediately after a successful login,
preventing the redundant unlock prompt.

---
*PR created automatically by Jules for task [15058867863395753644](https://jules.google.com/task/15058867863395753644) started by @redog*