### PR TITLE
feat: make interactive menu opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ winget install Rustlang.Rustup
 ### Usage
 
 ```powershell
-. ./init.ps1                # default flow (load keys + interactive menu)
+. ./init.ps1                # default flow (load keys)
 . ./init.ps1 -Reload        # force-reload keys even if already in env
 . ./init.ps1 -Reconfigure   # re-prompt for git config (name, email, gh user)
 ```
@@ -122,7 +122,7 @@ Bash implementation matching the PowerShell feature set.
 ### Usage
 
 ```bash
-# Quick start: install pre-reqs, load keys, install credential helper, run interactive menu.
+# Quick start: install pre-reqs, load keys, install credential helper.
 source <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/setup.sh)
 source <(curl -sS https://raw.githubusercontent.com/redog/git-init/master/init.sh)
 # todo add chezmoi tutorial:
@@ -131,7 +131,7 @@ source <(curl -fsLS get.chezmoi.io) -- init --apply git@github.com:redog/rc.git
 # Local clone, with options:
 source ./init.sh --reload         # force key reload
 source ./init.sh --reconfigure    # re-prompt for git identity
-source ./init.sh --no-menu        # set up env, skip the menu
+source ./init.sh --menu        # set up env and run interactive menu
 ./init.sh                          # executed (not sourced) — env stays in subshell
 ```
 

--- a/init.ps1
+++ b/init.ps1
@@ -1,5 +1,6 @@
 # Main entry point for the Git-Init script
 param(
+    [switch]$Menu,
     [switch]$Reconfigure,
     [switch]$Reload
 )
@@ -149,104 +150,106 @@ echo "password=`$token"
     }
 }
 
-# Prompt user for action
-$title = "Git-Init"
-$message = "What would you like to do?"
-$choices = [System.Management.Automation.Host.ChoiceDescription[]]@(
-    (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList '&New repository', 'Create a new repository'),
-    (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList '&Clone existing repository', 'Clone an existing repository'),
-    (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList 'Continue to &shell', 'Exit the script and continue to shell')
-)
+if ($Menu) {
+    # Prompt user for action
+    $title = "Git-Init"
+    $message = "What would you like to do?"
+    $choices = [System.Management.Automation.Host.ChoiceDescription[]]@(
+        (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList '&New repository', 'Create a new repository'),
+        (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList '&Clone existing repository', 'Clone an existing repository'),
+        (New-Object System.Management.Automation.Host.ChoiceDescription -ArgumentList 'Continue to &shell', 'Exit the script and continue to shell')
+    )
 
-$choice = $Host.UI.PromptForChoice($title, $message, $choices, 0)
+    $choice = $Host.UI.PromptForChoice($title, $message, $choices, 0)
 
-if ($choice -eq 0) {
-    # Create new repo
-    $repoName = Read-Host "Enter the name for the new repository"
+    if ($choice -eq 0) {
+        # Create new repo
+        $repoName = Read-Host "Enter the name for the new repository"
 
-    # Determine GitHub username
-    $username = $null
-    if (-not $Reconfigure) {
-        $username = Get-GHUser
-    }
-    if ([string]::IsNullOrWhiteSpace($username)) {
-        $username = Read-Host "Enter your GitHub username"
-    }
-
-    # Determine Name
-    $name = $null
-    if (-not $Reconfigure) {
-        $name = git config --global user.name
-    }
-    if ([string]::IsNullOrWhiteSpace($name)) {
-        $name = Read-Host "Enter your full name"
-    }
-
-    # Determine Email
-    $email = $null
-    if (-not $Reconfigure) {
-        $email = git config --global user.email
-    }
-    if ([string]::IsNullOrWhiteSpace($email)) {
-        $email = Read-Host "Enter your email address"
-    }
-
-    $repo = New-GHRepository -RepoName $repoName
-    if ($repo) {
-        Write-Host "Repository '$($repo.full_name)' created successfully."
-        Initialize-LocalGitRepository -RepoName $repoName -Username $username -Name $name -Email $email
-    }
-}
-elseif ($choice -eq 1) {
-    # Clone existing repo
-    $repositories = @(Get-GHRepositories | Sort-Object)
-    if ($repositories) {
-        Write-Host "Select a repository to clone:"
-        for ($i = 0; $i -lt $repositories.Count; $i++) {
-            Write-Host "$($i + 1). $($repositories[$i])"
+        # Determine GitHub username
+        $username = $null
+        if (-not $Reconfigure) {
+            $username = Get-GHUser
+        }
+        if ([string]::IsNullOrWhiteSpace($username)) {
+            $username = Read-Host "Enter your GitHub username"
         }
 
-        while ($true) {
-            $selection = Read-Host "Enter repository number (1-$($repositories.Count))"
-            if ($selection -match '^\d+$' -and [int]$selection -ge 1 -and [int]$selection -le $repositories.Count) {
-                $selectedRepo = $repositories[[int]$selection - 1]
-                break
+        # Determine Name
+        $name = $null
+        if (-not $Reconfigure) {
+            $name = git config --global user.name
+        }
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            $name = Read-Host "Enter your full name"
+        }
+
+        # Determine Email
+        $email = $null
+        if (-not $Reconfigure) {
+            $email = git config --global user.email
+        }
+        if ([string]::IsNullOrWhiteSpace($email)) {
+            $email = Read-Host "Enter your email address"
+        }
+
+        $repo = New-GHRepository -RepoName $repoName
+        if ($repo) {
+            Write-Host "Repository '$($repo.full_name)' created successfully."
+            Initialize-LocalGitRepository -RepoName $repoName -Username $username -Name $name -Email $email
+        }
+    }
+    elseif ($choice -eq 1) {
+        # Clone existing repo
+        $repositories = @(Get-GHRepositories | Sort-Object)
+        if ($repositories) {
+            Write-Host "Select a repository to clone:"
+            for ($i = 0; $i -lt $repositories.Count; $i++) {
+                Write-Host "$($i + 1). $($repositories[$i])"
             }
-            Write-Warning "Invalid selection."
-        }
 
-        # Clone using credential helper to avoid prompts
-        $helperScript = Join-Path $HOME ".config/git-credential-env"
-        if ($IsLinux) {
-            git -c credential.helper=$helperScript clone "https://github.com/$selectedRepo.git"
-        }
-        elseif ($IsMacOS) {
-            git -c credential.helper=osxkeychain clone "https://github.com/$selectedRepo.git"
-        }
-        else {
-            git -c credential.helper=manager clone "https://github.com/$selectedRepo.git"
-        }
+            while ($true) {
+                $selection = Read-Host "Enter repository number (1-$($repositories.Count))"
+                if ($selection -match '^\d+$' -and [int]$selection -ge 1 -and [int]$selection -le $repositories.Count) {
+                    $selectedRepo = $repositories[[int]$selection - 1]
+                    break
+                }
+                Write-Warning "Invalid selection."
+            }
 
-        $repoName = Split-Path $selectedRepo -Leaf
-        if (Test-Path $repoName) {
-            Push-Location $repoName
+            # Clone using credential helper to avoid prompts
+            $helperScript = Join-Path $HOME ".config/git-credential-env"
             if ($IsLinux) {
-                git config credential.helper $helperScript
+                git -c credential.helper=$helperScript clone "https://github.com/$selectedRepo.git"
             }
             elseif ($IsMacOS) {
-                git config credential.helper osxkeychain
+                git -c credential.helper=osxkeychain clone "https://github.com/$selectedRepo.git"
             }
             else {
-                git config credential.helper manager
+                git -c credential.helper=manager clone "https://github.com/$selectedRepo.git"
             }
-            git config remote.origin.url "https://github.com/$selectedRepo.git"
-            Write-Host "Clone complete. Credential helper configured."
-            Pop-Location
-        } else {
-            Write-Warning "Failed to clone repository. Please check the cloned repository."
+
+            $repoName = Split-Path $selectedRepo -Leaf
+            if (Test-Path $repoName) {
+                Push-Location $repoName
+                if ($IsLinux) {
+                    git config credential.helper $helperScript
+                }
+                elseif ($IsMacOS) {
+                    git config credential.helper osxkeychain
+                }
+                else {
+                    git config credential.helper manager
+                }
+                git config remote.origin.url "https://github.com/$selectedRepo.git"
+                Write-Host "Clone complete. Credential helper configured."
+                Pop-Location
+            } else {
+                Write-Warning "Failed to clone repository. Please check the cloned repository."
+            }
         }
-    } 
-}
-elseif ($choice -eq 2) {
-    Write-Host "Continuing to shell..."
+    }
+    elseif ($choice -eq 2) {
+        Write-Host "Continuing to shell..."
+    }
 }

--- a/init.sh
+++ b/init.sh
@@ -755,14 +755,14 @@ gi_print_help() {
 git-init $GI_VERSION
 
 Usage:
-  source init.sh [--reload] [--reconfigure] [--no-menu]
+  source init.sh [--reload] [--reconfigure] [--menu]
   ./init.sh     [--reload] [--reconfigure]
 
 Options:
   --reload        Force reload of API keys even if env vars are already set.
   --reconfigure   Re-prompt for git config (name, email, GitHub user) instead of
                   reading existing values.
-  --no-menu       (sourced only) Set up keys/credential helper but skip the
+  --menu          (sourced only) Set up keys/credential helper and run the
                   interactive menu.
   -h, --help      Show this help.
 
@@ -796,12 +796,12 @@ EOF
 _gi_main_body() {
   set -euo pipefail
 
-  local reconfigure=0 reload=0 no_menu=0
+  local reconfigure=0 reload=0 show_menu=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --reconfigure) reconfigure=1; shift ;;
       --reload)      reload=1; shift ;;
-      --no-menu)     no_menu=1; shift ;;
+      --menu)     show_menu=1; shift ;;
       -h|--help)     gi_print_help; return 0 ;;
       *) echo "Unknown argument: $1" >&2; gi_print_help >&2; return 2 ;;
     esac
@@ -876,7 +876,7 @@ _gi_main_body() {
 
   gi_ensure_credential_helper
 
-  if (( _GI_SOURCED && no_menu )); then
+  if (( _GI_SOURCED && ! show_menu )); then
     return 0
   fi
 


### PR DESCRIPTION
Make interactive menu opt-in instead of opt-out

Changes:
- Replaced the `--no-menu` option with `--menu` in `init.sh`. The default behavior when sourced is now to only set up the environment, and the user must explicitly pass `--menu` to get the interactive prompt.
- Added a `[switch]$Menu` parameter to `init.ps1`. The script now skips the interactive prompt unless `-Menu` is specified.
- Updated `README.md` to reflect that the default behavior is just setting up the environment.

---
*PR created automatically by Jules for task [16881165660709699156](https://jules.google.com/task/16881165660709699156) started by @redog*