### PR TITLE
fix: Add missing exported functions to APIKeys.psd1

### DIFF
--- a/APIKeys/APIKeys.psd1
+++ b/APIKeys/APIKeys.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'APIKeys.psm1'
-    ModuleVersion     = '0.1.0'
+    ModuleVersion     = '0.1.1'
     GUID              = '00000000-0000-0000-0000-000000000000'
     Author            = 'Eric Ortego'
     Description       = 'Loads API keys from Bitwarden Secrets Manager into environment variables.'
@@ -9,7 +9,10 @@
         'Get-BwsSecretValue','Get-APIKeyMap','Set-AllAPIKeys','Clear-APIKeyEnv',
         'Set-APIKeysConfig','Import-APIKeysConfig','Connect-Bitwarden',
         'Show-APIKeysConfig','Save-APIKeysConfig','Get-APIKeysConfigPath',
-        'Initialize-APIKeysConfigFile','Add-APIKey','Remove-APIKey','Set-APIKeysConfigField'
+        'Initialize-APIKeysConfigFile','Add-APIKey','Remove-APIKey','Set-APIKeysConfigField',
+        'Save-GitInitCredential','Get-GitInitCredential','Remove-GitInitCredential',
+        'Save-GitInitSession','Restore-GitInitSession','Clear-GitInitSession',
+        'Set-GitInitVerbosity','Write-GitInitLog'
     )
     AliasesToExport   = @('load_keys')
 }


### PR DESCRIPTION
This PR fixes an issue where newly added functions such as `Set-GitInitVerbosity` and `Write-GitInitLog` were not recognized during the execution of `init.ps1`. The error occurred because while the functions were present in `APIKeys.psm1`, they were not explicitly exported in the module manifest `APIKeys.psd1`.

Changes:
* Added missing functions (`Save-GitInitCredential`, `Get-GitInitCredential`, `Remove-GitInitCredential`, `Save-GitInitSession`, `Restore-GitInitSession`, `Clear-GitInitSession`, `Set-GitInitVerbosity`, and `Write-GitInitLog`) to `FunctionsToExport` in `APIKeys/APIKeys.psd1`.
* Bumped `ModuleVersion` from `0.1.0` to `0.1.1`.

---
*PR created automatically by Jules for task [753045873361981314](https://jules.google.com/task/753045873361981314) started by @redog*