### PR TITLE
fix: opportunistically restore BW_SESSION from OS keychain

### DIFF
--- a/APIKeys/APIKeys.psm1
+++ b/APIKeys/APIKeys.psm1
@@ -532,6 +532,15 @@ function Get-BwsAccessToken {
         [string]$BwsTokenItemIdOrName = $script:BwsTokenItem
     )
 
+    # Opportunistically restore BW_SESSION from the OS keychain if not set,
+    # so the user can use the 'bw' CLI tool even if we only need the 'bws' token.
+    if (-not $env:BW_SESSION) {
+        $cachedSession = Get-GitInitCredential -Key 'bw_session'
+        if (-not [string]::IsNullOrWhiteSpace($cachedSession)) {
+            $env:BW_SESSION = $cachedSession
+        }
+    }
+
     if (-not $env:BWS_ACCESS_TOKEN) {
         # Try the OS keychain for a previously saved BWS token (avoids BW unlock).
         $cached = Get-GitInitCredential -Key 'bws_token'

--- a/init.sh
+++ b/init.sh
@@ -481,6 +481,14 @@ gi_connect_bitwarden() {
 }
 
 gi_get_bws_token() {
+  # Opportunistically restore BW_SESSION from the OS keychain if not set,
+  # so the user can use the 'bw' CLI tool even if we only need the 'bws' token.
+  if [[ -z "${BW_SESSION:-}" ]]; then
+    local _cached_session
+    _cached_session=$(gi_keychain_load "bw_session" 2>/dev/null || true)
+    [[ -n "$_cached_session" ]] && export BW_SESSION="$_cached_session"
+  fi
+
   if [[ -n "${BWS_ACCESS_TOKEN:-}" ]]; then
     return 0
   fi


### PR DESCRIPTION
Fixes an issue where `BW_SESSION` was not exported if `BWS_ACCESS_TOKEN` was cached, forcing manual unlocks for subsequent `bw` commands.

---
*PR created automatically by Jules for task [1917076732534960637](https://jules.google.com/task/1917076732534960637) started by @redog*