### PR TITLE
Fix cross-module scope bugs, config lookup order, and doc drift

### DIFF
--- a/APIKeys/KeyRotation.psm1
+++ b/APIKeys/KeyRotation.psm1
@@ -9,8 +9,9 @@ function Update-VaultAPIKey {
     .SYNOPSIS
         Updates an API key in Bitwarden Secrets Manager and reloads it into the current session.
     .DESCRIPTION
-        Takes an API key mapped in your config.psd1, updates its value in BWS using the CLI,
-        and then calls Set-AllAPIKeys to update your current environment variables.
+        Takes an API key mapped in your config (config.json, or legacy .psd1), updates its
+        value in BWS using the CLI, and then calls Set-AllAPIKeys to update your current
+        environment variables.
     .PARAMETER Name
         The friendly name of the key as defined in your KeyMap (e.g., 'GitHub', 'OpenAI').
     .PARAMETER NewValue
@@ -42,7 +43,7 @@ function Update-VaultAPIKey {
     $entry = $keyMap | Where-Object { $_.Name -eq $Name }
 
     if (-not $entry) {
-        throw "Could not find a key mapped to '$Name' in the configuration. Check your config.psd1."
+        throw "Could not find a key mapped to '$Name' in the configuration. Check your config with Show-APIKeysConfig."
     }
 
     $secretId = $entry.SecretId
@@ -56,8 +57,12 @@ function Update-VaultAPIKey {
 
     # 3. Use BWS CLI to edit the secret
     try {
-        # The BWS CLI secret edit command updates the value
-        $bwsCliPath = if ([string]::IsNullOrWhiteSpace($script:BwsCliPath)) { 'bws' } else { $script:BwsCliPath }
+        # The BWS CLI secret edit command updates the value. The configured
+        # CLI path lives in the APIKeys module scope (not this module's), so
+        # read it through the exported accessor — under StrictMode a bare
+        # $script:BwsCliPath reference here would throw.
+        $bwsCliPath = (Show-APIKeysConfig).BwsCliPath
+        if ([string]::IsNullOrWhiteSpace($bwsCliPath)) { $bwsCliPath = 'bws' }
         $editOutput = & $bwsCliPath secret edit $secretId --value $NewValue -o json | ConvertFrom-Json
         
         if ($null -eq $editOutput -or $editOutput.id -ne $secretId) {

--- a/APIKeys/README.md
+++ b/APIKeys/README.md
@@ -9,13 +9,14 @@ Data Files (`.psd1`) are still accepted for backwards compatibility.
 ## Features
 
 - **Secure Retrieval:** Fetches secrets directly from BWS into environment variables.
-- **Flexible Configuration:** Map any secret to any environment variable using a `.psd1` file.
+- **Flexible Configuration:** Map any secret to any environment variable using a JSON config file (legacy `.psd1` also accepted).
 - **Bitwarden Integration:** Automatically handles `bws` authentication using a BWS Access Token stored in your Bitwarden Vault.
 - **Session Management:** Can clear injected secrets from the environment.
 
 ## Configuration
 
-The module is configured using a hashtable, typically loaded from a `.psd1` file.
+The module is configured using a hashtable, typically loaded from a `.json` file
+(via `Import-APIKeysConfig`); legacy `.psd1` files are still supported.
 
 ### Config File Structure (`config.json`)
 

--- a/GitInit/GitInit.psm1
+++ b/GitInit/GitInit.psm1
@@ -66,7 +66,7 @@ function Initialize-LocalGitRepository {
         return
     }
 
-    New-Item -ItemType Directory -Name $RepoName
+    New-Item -ItemType Directory -Name $RepoName | Out-Null
     Set-Location $RepoName
 
     git init

--- a/GitInit/README.md
+++ b/GitInit/README.md
@@ -25,6 +25,7 @@ Ensure you have the following installed and available in your PATH:
 *   **Bitwarden Secrets Manager** (`bws`)
 
         winget install Microsoft.VCRedist.2015+.x64
+        winget install Rustlang.Rustup
         ./MInstall-BWS.ps1
 
 ## Getting Started
@@ -37,7 +38,7 @@ Ensure you have the following installed and available in your PATH:
 
   1. The user must store their actual API key like GitHub's in the Bitwarden Secrets Manager.
   2. The Bitwarden Secrets Manager API key must be stored in the bitwarden vault.
-  3. Ceate or retrieve your Github access token.
+  3. Create or retrieve your GitHub access token.
     
          # Our example github access token
          github_pat_11111111112222222333333
@@ -54,7 +55,7 @@ Ensure you have the following installed and available in your PATH:
          -----------------------------------------------------------------------
          02c45a25-d69b-4540-a489-b3d1013ef541   git-init   2026-01-13 19:21:17
     
-    Armed with our new bws access token we can now store our other API tokens in it's secure vault.
+    Armed with our new bws access token we can now store our other API tokens in its secure vault.
           
           # Our example bws token
           eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMzQiLCJzY29wZSI6ImFwaSJ9.RmFrZVNpZ25hdHVyZQ

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ echo $PROFILE
 
 | Cmdlet / alias                     | Purpose                                                        |
 | ---------------------------------- | -------------------------------------------------------------- |
-| `Set-AllAPIKeys` / `load_keys`     | Load keys per `KeyMap` (`-Only`, `-Except`, `-Quiet`).         |
+| `Set-AllAPIKeys` / `load_keys`     | Load keys per `KeyMap` (`-Only`, `-Except`, `-Quiet`, `-NoCache`). |
 | `Clear-APIKeyEnv`                  | Unset all key-map env vars (`-ClearBitwardenSession`).         |
 | `Update-VaultAPIKey`               | Update a secret in BWS and reload it locally.                  |
 | `Get-APIKeyMap`                    | Print the loaded key map.                                      |
@@ -276,7 +276,7 @@ fi
 
 | Function                          | Purpose                                              |
 | --------------------------------- | ---------------------------------------------------- |
-| `gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet]` | Load keys per `KeyMap`. Per-key messages shown only at `-v`. |
+| `gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet] [--no-cache]` | Load keys per `KeyMap`. Per-key messages shown only at `-v`. |
 | `gi_clear_keys [--all]`           | Unset all key-map env vars (`--all` also clears session). |
 | `gi_update_key <name> [value]`    | Update a secret in BWS and reload it locally.        |
 | `gi_list_keys`                    | List `Name`, `SecretId`, env vars per entry.         |

--- a/init.ps1
+++ b/init.ps1
@@ -26,11 +26,13 @@ $_verbosity = if ($Quiet) { 0 } elseif ($VerbosePreference -eq 'Continue') { 2 }
 Set-GitInitVerbosity -Level $_verbosity
 
 # Load configuration. JSON is canonical (shared with init.sh); .psd1 kept for back-compat.
+# Lookup order matches init.sh and the README: $GIT_INIT_CONFIG, ~/.git-init.json,
+# <repo>/config.json, then the legacy .psd1 fallbacks.
 $configPath = $null
 foreach ($candidate in @(
     $env:GIT_INIT_CONFIG,
-    (Join-Path $ScriptDir 'config.json'),
     (Join-Path $UserHome  '.git-init.json'),
+    (Join-Path $ScriptDir 'config.json'),
     (Join-Path $ScriptDir 'config.psd1'),
     (Join-Path $UserHome  '.git-init.psd1')
 )) {
@@ -112,7 +114,9 @@ if ($configPath) {
 
     if ($shouldLoadKeys) {
         Write-GitInitLog -Level 1 -Message "Loading API Keys..."
-        Set-AllAPIKeys -NoCache:$Reload
+        # Discard the summary object; Set-AllAPIKeys already logs a summary
+        # line, and emitting the object would break -Quiet.
+        $null = Set-AllAPIKeys -NoCache:$Reload
     }
 }
 else {
@@ -121,20 +125,22 @@ else {
 
 # Verify GitHub Token
 if (-not $env:GITHUB_ACCESS_TOKEN) {
-    Write-Error "GITHUB_ACCESS_TOKEN is not set. Please ensure config.psd1 maps a secret to this environment variable and that you have authenticated with Bitwarden."
+    Write-Error "GITHUB_ACCESS_TOKEN is not set. Please ensure your config's KeyMap maps a secret to this environment variable and that you have authenticated with Bitwarden."
     return
 }
 
 # Ensure git-credential-env exists on Linux/macOS
 if ($IsLinux -or $IsMacOS) {
-    $configDir = Join-Path $HOME ".config"
+    $configDir = Join-Path $UserHome ".config"
     if (-not (Test-Path $configDir)) {
         New-Item -ItemType Directory -Path $configDir | Out-Null
     }
 
     $helperScript = Join-Path $configDir "git-credential-env"
     if (-not (Test-Path $helperScript)) {
-        $bwsCliPath = $script:BwsCliPath
+        # $script:BwsCliPath lives in the APIKeys module scope, not this
+        # script's, so read it through the exported accessor.
+        $bwsCliPath = (Show-APIKeysConfig).BwsCliPath
         if ([string]::IsNullOrWhiteSpace($bwsCliPath)) { $bwsCliPath = 'bws' }
         $helperContent = @"
 #!/usr/bin/env bash
@@ -226,7 +232,7 @@ if ($Menu) {
             }
 
             # Clone using credential helper to avoid prompts
-            $helperScript = Join-Path $HOME ".config/git-credential-env"
+            $helperScript = Join-Path $UserHome ".config/git-credential-env"
             if ($IsLinux) {
                 git -c credential.helper=$helperScript clone "https://github.com/$selectedRepo.git"
             }

--- a/init.sh
+++ b/init.sh
@@ -272,7 +272,8 @@ gi_config_add_key() {
       [Gg]it[Hh]ub)        default_var="GITHUB_ACCESS_TOKEN" ;;
       [Oo]pen[Aa][Ii])     default_var="OPENAI_API_KEY" ;;
       [Aa]nthropic)        default_var="ANTHROPIC_API_KEY" ;;
-      *)                   default_var="$(echo "$name" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9' '_')_API_KEY" ;;
+      # printf (not echo) so the trailing newline isn't translated into a stray '_'.
+      *)                   default_var="$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9' '_')_API_KEY" ;;
     esac
     local var
     printf "Environment variable name [%s]: " "$default_var"
@@ -948,7 +949,8 @@ Usage:
   ./init.sh     [--reload] [--reconfigure] [-v] [-q]
 
 Options:
-  --reload        Force reload of API keys even if env vars are already set.
+  --reload        Force reload of API keys even if env vars are already set,
+                  bypassing the OS keychain cache (re-fetches from BWS).
   --reconfigure   Re-prompt for git config (name, email, GitHub user) instead of
                   reading existing values.
   --menu          (sourced only) Set up keys/credential helper and run the
@@ -960,7 +962,7 @@ Options:
 Functions exposed when sourced:
 
   Key loading / management:
-    gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet]
+    gi_load_keys [--only N1,N2] [--except N1,N2] [--quiet] [--no-cache]
     gi_clear_keys [--all]
     gi_update_key <name> [new-value]
     gi_list_keys

--- a/mkrepo.sh
+++ b/mkrepo.sh
@@ -98,7 +98,9 @@ if [[ -z $(git config --global --get push.default) ]]; then
   git config --global push.default simple
 fi
 
-repo_exists=$(curl -fsSL -H "Authorization: token ${token}" "https://api.github.com/repos/${username}/${repo}")
+# '|| true' so a failed lookup reaches the error message below instead of
+# aborting silently via set -e.
+repo_exists=$(curl -fsSL -H "Authorization: token ${token}" "https://api.github.com/repos/${username}/${repo}" || true)
 if [[ -z ${repo_exists} ]]; then
   echo "GitHub repo ${username}/${repo} does not exist" >&2
   exit 1
@@ -107,7 +109,7 @@ fi
 git remote add origin "https://github.com/${username}/${repo}.git"
 
 echo  "${repo} by ${username}" > README.md
-curl https://www.gnu.org/licenses/gpl-3.0.txt > LICENSE
+curl -fsSL https://www.gnu.org/licenses/gpl-3.0.txt > LICENSE
 
 git add .
 git commit -m "Initial commit"


### PR DESCRIPTION
Review of the init scripts for egregious errors, overlooked issues, and documentation/comment drift. The interactive flows (prompts, `bw login`/`bw unlock`, the create/clone menu) are untouched — every fix here is about correctness around them.

## Bugs

- **`Update-VaultAPIKey` was broken** (`APIKeys/KeyRotation.psm1`): it read `$script:BwsCliPath`, which is never set in *that* module's scope, and the module runs under `Set-StrictMode -Version Latest` — so the reference threw inside the `try`, was caught, and every rotation attempt failed with "Failed to update secret in BWS". Now reads the configured CLI path via the exported `Show-APIKeysConfig`.
- **Same cross-module reference in `init.ps1`**: when writing `~/.config/git-credential-env`, `$script:BwsCliPath` resolved to `$null` (script scope, no StrictMode), so a custom `BwsCliPath` was silently ignored and `bws` was always embedded in the helper.
- **Config lookup order mismatch** (`init.ps1`): the PowerShell front-end checked `<repo>/config.json` *before* `~/.git-init.json` — the opposite of both `init.sh` and the README's documented order. With both files present, the two front-ends silently loaded different configs. Reordered to match the documented order.
- **`-Quiet` wasn't quiet** (`init.ps1`): the `Set-AllAPIKeys` summary object (`Success/Failed/Total`) leaked to the pipeline and printed a table even with `-Quiet` — noisy for the documented `$PROFILE` integration. The object is now discarded; the human-readable summary line (verbosity-gated) already covers it.
- **`$HOME` vs `$UserHome`** (`init.ps1`): the script resolves `$UserHome` specifically because `$HOME` can be unset/wrong on some setups, but the `.config` helper paths still used `$HOME`. Now consistent.
- **Stray underscore in suggested env var names** (`init.sh`): `gi_config_add_key my-key` suggested `MY_KEY__API_KEY` because `echo`'s trailing newline was translated by `tr -c` into a `_`. Uses `printf '%s'` now.
- **Dead error path under `set -e`** (`mkrepo.sh`): the repo-existence `curl -f` aborted the script on failure before the "does not exist" message could print. Also added `-fsSL` to the LICENSE download so an HTTP error page can't be written into `LICENSE`.
- **Pipeline noise** (`GitInit/GitInit.psm1`): `New-Item` printed a `DirectoryInfo` table in the middle of the interactive create flow; piped to `Out-Null`.

## Documentation / comment drift

- Error messages and docstrings still told users to check `config.psd1`, though JSON has been the canonical shared config since the unified-config change (`init.ps1`, `KeyRotation.psm1`).
- `APIKeys/README.md` still described the config as "typically loaded from a `.psd1` file".
- `--no-cache` / `-NoCache` existed in `gi_load_keys` / `Set-AllAPIKeys` but were missing from the script help text and both README function tables; the `--reload` help line now also mentions that it bypasses the OS keychain cache (matching the README's cache-invalidation section).
- `GitInit/README.md`: added the `Rustlang.Rustup` install step that `MInstall-BWS.ps1` hard-requires (it throws without cargo); fixed "Ceate" → "Create" and "it's" → "its".

## Verification

- `bash -n` passes for `init.sh`, `mkrepo.sh`, `setup.sh`; `source init.sh --help` still loads all `gi_*` functions cleanly.
- Verified the `tr` fix: `my-key` → `MY_KEY_API_KEY` (was `MY_KEY__API_KEY`).
- PowerShell changes verified by review (no `pwsh` in this environment); each is a scope/pipeline fix with a `'bws'` fallback preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TVBru91xxJ4q6mJ5J8vfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011TVBru91xxJ4q6mJ5J8vfZ)_