### PR TITLE
Add optional master password storage for prompt-free vault unlocks

### DIFF
--- a/APIKeys/APIKeys.psd1
+++ b/APIKeys/APIKeys.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'APIKeys.psm1'
-    ModuleVersion     = '0.1.1'
+    ModuleVersion     = '0.2.0'
     GUID              = '00000000-0000-0000-0000-000000000000'
     Author            = 'Eric Ortego'
     Description       = 'Loads API keys from Bitwarden Secrets Manager into environment variables.'
@@ -12,6 +12,7 @@
         'Initialize-APIKeysConfigFile','Add-APIKey','Remove-APIKey','Set-APIKeysConfigField',
         'Save-GitInitCredential','Get-GitInitCredential','Remove-GitInitCredential',
         'Save-GitInitSession','Restore-GitInitSession','Clear-GitInitSession',
+        'Save-GitInitMasterPassword','Remove-GitInitMasterPassword','Test-GitInitMasterPassword',
         'Set-GitInitVerbosity','Write-GitInitLog'
     )
     AliasesToExport   = @('load_keys')

--- a/APIKeys/APIKeys.psm1
+++ b/APIKeys/APIKeys.psm1
@@ -319,7 +319,21 @@ function Save-GitInitCredential {
             $vault.Add((New-Object Windows.Security.Credentials.PasswordCredential($svc, $Key, $Value)))
         }
         'macos' {
-            & security add-generic-password -s $svc -a $Key -w $Value -U 2>$null
+            # Passing the value as `-w <value>` argv would expose it in the
+            # process list (`ps`) for the duration of the call, so feed the
+            # whole command to `security -i` on stdin instead. The interactive
+            # parser understands backslash escapes inside double quotes but
+            # only takes single-line commands, so values with embedded
+            # newlines fall back to the argv form.
+            if ($Value -match "[`r`n]") {
+                & security add-generic-password -s $svc -a $Key -w $Value -U 2>$null
+            }
+            else {
+                $escKey = $Key.Replace('\', '\\').Replace('"', '\"')
+                $escVal = $Value.Replace('\', '\\').Replace('"', '\"')
+                "add-generic-password -U -s `"$svc`" -a `"$escKey`" -w `"$escVal`"" |
+                    & security -i 2>$null | Out-Null
+            }
         }
         'secret-tool' {
             $Value | & secret-tool store --label="git-init: $Key" service $svc account $Key 2>$null
@@ -429,9 +443,17 @@ function Clear-GitInitSession {
     .DESCRIPTION
         Clears BW_SESSION, BWS_ACCESS_TOKEN, and every cached secret value (keyed by SecretId).
         Call this after a token rotation or to force a full re-authentication on the next run.
+
+        The stored master password (see Save-GitInitMasterPassword) is deliberately
+        kept unless -IncludeMasterPassword is given: sessions are expiring caches,
+        the password is a deliberate opt-in.
+    .PARAMETER IncludeMasterPassword
+        Also remove the stored Bitwarden master password from the keychain.
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [switch]$IncludeMasterPassword
+    )
     Remove-GitInitCredential -Key 'bw_session'
     Remove-GitInitCredential -Key 'bws_token'
     Remove-Item -Path Env:BW_SESSION       -ErrorAction SilentlyContinue
@@ -445,7 +467,119 @@ function Clear-GitInitSession {
         }
     }
 
+    if ($IncludeMasterPassword) {
+        Remove-GitInitCredential -Key 'bw_master_password'
+        Write-Host "Master password removed from keychain." -ForegroundColor DarkGray
+    }
+
     Write-Host "Session cleared from keychain." -ForegroundColor DarkGray
+}
+
+#------------------------------------------------------------------------------
+# Master password storage (explicit opt-in)
+#------------------------------------------------------------------------------
+# Trade-off: cached sessions expire, the master password does not. Anything
+# that can read your unlocked login keychain / credential store can read it.
+# Storing it buys fully prompt-free unlocks (combined with BW_CLIENTID /
+# BW_CLIENTSECRET login, a fully headless cold start); only opt in on machines
+# where that trade is acceptable. Nothing here ever stores the password
+# without Save-GitInitMasterPassword being called (or init.ps1's
+# -RememberPassword switch, which calls it).
+
+function Save-GitInitMasterPassword {
+    <#
+    .SYNOPSIS
+        Opt-in: stores the Bitwarden master password in the OS keychain.
+    .DESCRIPTION
+        Prompts for the master password (never echoed; deliberately not accepted
+        as a parameter so it cannot leak into shell history), validates it by
+        actually unlocking the vault, and only stores it after a successful
+        unlock. Connect-Bitwarden then uses it to unlock without prompting.
+
+        Remove it with Remove-GitInitMasterPassword or
+        Clear-GitInitSession -IncludeMasterPassword.
+    .OUTPUTS
+        [bool] $true if the password was validated and stored.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ((Get-KeychainBackend) -eq 'none') {
+        Write-Error "No keychain backend available; refusing to store the master password. Install libsecret (provides secret-tool) on Linux."
+        return $false
+    }
+    if (-not (Get-Command bw -ErrorAction SilentlyContinue)) {
+        Write-Error "Bitwarden CLI 'bw' not found in PATH."
+        return $false
+    }
+    $status = (bw status | ConvertFrom-Json).status
+    if ($status -eq 'unauthenticated') {
+        Write-Error "Bitwarden CLI is not logged in, so the password cannot be validated. Run Connect-Bitwarden (or 'bw login') first."
+        return $false
+    }
+
+    $secure = Read-Host "Bitwarden master password (will be stored in the OS keychain)" -AsSecureString
+    $password = ConvertFrom-SecureString -SecureString $secure -AsPlainText
+    if ([string]::IsNullOrEmpty($password)) {
+        Write-Error "Empty password; nothing stored."
+        return $false
+    }
+
+    # Validate via the env-var handoff: never touches disk or argv.
+    $session = $null
+    try {
+        $env:BW_PASSWORD = $password
+        $session = bw unlock --passwordenv BW_PASSWORD --raw 2>$null
+        if ($LASTEXITCODE -ne 0) { $session = $null }
+    }
+    finally {
+        Remove-Item -Path Env:BW_PASSWORD -ErrorAction SilentlyContinue
+    }
+    if ([string]::IsNullOrWhiteSpace($session)) {
+        Write-Error "That password did not unlock the vault; nothing stored."
+        return $false
+    }
+
+    # The unlock we just did is a perfectly good session — keep it.
+    $env:BW_SESSION = $session.Trim()
+    Save-GitInitCredential -Key 'bw_session' -Value $env:BW_SESSION
+    Write-GitInitLog -Level 2 -Message "BW session saved to keychain." -Color DarkGray
+
+    Save-GitInitCredential -Key 'bw_master_password' -Value $password
+    # Read back to verify: the hardened macOS path pipes through `security -i`,
+    # whose exit status is not a reliable success signal.
+    if ((Get-GitInitCredential -Key 'bw_master_password') -cne $password) {
+        Remove-GitInitCredential -Key 'bw_master_password'
+        Write-Error "Stored master password failed read-back verification; check your keychain backend."
+        return $false
+    }
+    Write-Host "Master password saved to keychain. Remove it with Remove-GitInitMasterPassword." -ForegroundColor DarkGray
+    return $true
+}
+
+function Remove-GitInitMasterPassword {
+    <#
+    .SYNOPSIS
+        Removes the stored Bitwarden master password from the OS keychain.
+    #>
+    [CmdletBinding()]
+    param()
+    if ([string]::IsNullOrEmpty((Get-GitInitCredential -Key 'bw_master_password'))) {
+        Write-Host "No master password stored in the keychain."
+        return
+    }
+    Remove-GitInitCredential -Key 'bw_master_password'
+    Write-Host "Master password removed from keychain." -ForegroundColor DarkGray
+}
+
+function Test-GitInitMasterPassword {
+    <#
+    .SYNOPSIS
+        Returns $true if a Bitwarden master password is stored in the OS keychain.
+    #>
+    [CmdletBinding()]
+    param()
+    -not [string]::IsNullOrEmpty((Get-GitInitCredential -Key 'bw_master_password'))
 }
 
 # endregion
@@ -460,8 +594,9 @@ function Connect-Bitwarden {
         - Restores a saved BW session from the OS keychain before checking status.
         - If unauthenticated: purges stale keychain entries, then logs in via API key
           or interactive prompt, and saves the new session to the keychain.
-        - If locked: purges stale keychain entries, unlocks interactively, and saves
-          the new session to the keychain.
+        - If locked: purges stale keychain entries, unlocks with the stored master
+          password when one exists (see Save-GitInitMasterPassword) or interactively
+          otherwise, and saves the new session to the keychain.
     #>
     [CmdletBinding()]
     param(
@@ -516,15 +651,44 @@ function Connect-Bitwarden {
 
     if ($status.status -eq 'locked') {
         # Vault locked — any cached session has expired; clear it and unlock.
+        # Note: the stored master password is NOT purged here; being locked (or
+        # even logged out) does not make the password wrong. It is only removed
+        # when it actually fails to unlock, or explicitly by the user.
         Remove-GitInitCredential -Key 'bw_session'
         Remove-GitInitCredential -Key 'bws_token'
         Remove-Item -Path Env:BW_SESSION       -ErrorAction SilentlyContinue
         Remove-Item -Path Env:BWS_ACCESS_TOKEN -ErrorAction SilentlyContinue
 
-        Write-GitInitLog -Level 1 -Message "🔓 Unlocking Vault..." -Color Cyan
-        $session = bw unlock --raw
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($session)) {
-            throw "Failed to unlock bw vault (could not obtain session key)."
+        $session = $null
+        # A stored master password (opt-in via Save-GitInitMasterPassword)
+        # unlocks without prompting. The env-var handoff never touches disk or
+        # argv. If it stops working (password changed), remove it so we never
+        # loop on a bad credential, then fall through to the interactive prompt.
+        $storedPw = Get-GitInitCredential -Key 'bw_master_password'
+        if (-not [string]::IsNullOrEmpty($storedPw)) {
+            Write-GitInitLog -Level 1 -Message "🔓 Unlocking Vault with stored master password..." -Color Cyan
+            try {
+                $env:BW_PASSWORD = $storedPw
+                $session = bw unlock --passwordenv BW_PASSWORD --raw 2>$null
+                if ($LASTEXITCODE -ne 0) { $session = $null }
+            }
+            finally {
+                Remove-Item -Path Env:BW_PASSWORD -ErrorAction SilentlyContinue
+            }
+            if ([string]::IsNullOrWhiteSpace($session)) {
+                $session = $null
+                Remove-GitInitCredential -Key 'bw_master_password'
+                Write-Warning "Stored master password no longer unlocks the vault; removed it from the keychain."
+            }
+            $storedPw = $null
+        }
+
+        if (-not $session) {
+            Write-GitInitLog -Level 1 -Message "🔓 Unlocking Vault..." -Color Cyan
+            $session = bw unlock --raw
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($session)) {
+                throw "Failed to unlock bw vault (could not obtain session key)."
+            }
         }
         $env:BW_SESSION = $session.Trim()
         Save-GitInitCredential -Key 'bw_session' -Value $env:BW_SESSION
@@ -757,5 +921,6 @@ Export-ModuleMember -Function `
     Initialize-APIKeysConfigFile, Add-APIKey, Remove-APIKey, Set-APIKeysConfigField, `
     Save-GitInitCredential, Get-GitInitCredential, Remove-GitInitCredential, `
     Save-GitInitSession, Restore-GitInitSession, Clear-GitInitSession, `
+    Save-GitInitMasterPassword, Remove-GitInitMasterPassword, Test-GitInitMasterPassword, `
     Set-GitInitVerbosity, Write-GitInitLog `
     -Alias load_keys

--- a/APIKeys/README.md
+++ b/APIKeys/README.md
@@ -12,6 +12,8 @@ Data Files (`.psd1`) are still accepted for backwards compatibility.
 - **Flexible Configuration:** Map any secret to any environment variable using a JSON config file (legacy `.psd1` also accepted).
 - **Bitwarden Integration:** Automatically handles `bws` authentication using a BWS Access Token stored in your Bitwarden Vault.
 - **Session Management:** Can clear injected secrets from the environment.
+- **OS Keychain Caching:** Persists the vault session, BWS token, and secret values in the native credential store (Windows Credential Manager / macOS Keychain / Linux libsecret) so new shells load without prompts or network calls.
+- **Optional Master-Password Storage:** Explicit opt-in to store the Bitwarden master password in the OS keychain for fully prompt-free unlocks — with just as explicit removal.
 
 ## Configuration
 
@@ -95,3 +97,54 @@ Removes the environment variables set by the module.
 ```powershell
 Clear-APIKeyEnv -ClearBitwardenSession
 ```
+
+## Keychain & Session Functions
+
+All credentials are stored in the OS-native credential store under the
+`git-init` service (Windows Credential Manager, macOS Keychain, or Linux
+GNOME Keyring / libsecret via `secret-tool`).
+
+### `Clear-GitInitSession`
+
+Removes the cached vault session, BWS token, and every cached secret value
+from the keychain, and unsets them in the environment.
+
+- **`-IncludeMasterPassword`**: Also remove the stored master password (kept by default — sessions are expiring caches, the password is a deliberate opt-in).
+
+```powershell
+Clear-GitInitSession                        # session + secrets only
+Clear-GitInitSession -IncludeMasterPassword # full wipe
+```
+
+### `Save-GitInitMasterPassword` (opt-in)
+
+Stores the Bitwarden master password in the OS keychain so `Connect-Bitwarden`
+can unlock the vault without ever prompting. The password is:
+
+- prompted for interactively — never accepted as a parameter, so it cannot leak into shell history;
+- **validated** by actually unlocking the vault before anything is stored;
+- handed to `bw unlock --passwordenv` via an environment variable, never via disk or a process argument list.
+
+If it ever stops unlocking the vault (e.g. after a password change),
+`Connect-Bitwarden` removes it from the keychain automatically and falls back
+to the interactive prompt.
+
+> **Trade-off:** cached sessions expire, the master password does not.
+> Anything that can read your unlocked credential store can read it. Only opt
+> in on machines where that is acceptable.
+
+```powershell
+Save-GitInitMasterPassword     # prompt, validate, store
+```
+
+### `Remove-GitInitMasterPassword` / `Test-GitInitMasterPassword`
+
+```powershell
+Test-GitInitMasterPassword     # $true if one is stored
+Remove-GitInitMasterPassword   # delete it from the keychain
+```
+
+### `Save-GitInitSession` / `Restore-GitInitSession`
+
+Manually save the current `BW_SESSION` / `BWS_ACCESS_TOKEN` to the keychain,
+or restore them into the environment. (The main flows do this automatically.)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ new shells load without any network calls or password prompts.
 | Bitwarden vault session | `bw_session` | Skips `bw unlock` master-password prompt |
 | BWS service-account token | `bws_token` | Skips fetching the token from the vault |
 | Each secret value | `secret:<uuid>` | Skips `bws secret get` network call per key |
+| Master password (**opt-in only**) | `bw_master_password` | Unlocks the vault without ever prompting — see below |
 
 The last point is the most impactful. Every `bws secret get` is an HTTPS round-trip
 (~100–300 ms each). With a full warm cache the entire load sequence is local
@@ -108,6 +109,62 @@ gi_session_clear && source init.sh
 # PowerShell — wipe all cached credentials (session + every secret)
 Clear-GitInitSession; . ./init.ps1
 ```
+
+The wipes above deliberately leave the stored master password (if you opted in
+— see next section) in place. To remove that too, use `gi_session_clear --all`
+/ `Clear-GitInitSession -IncludeMasterPassword`, or the dedicated commands
+below.
+
+### Optional: store the master password
+
+By default the one thing that is never cached is the Bitwarden master password:
+when the vault session expires you get a `bw unlock` prompt. If you opt in,
+git-init stores the master password itself in the OS keychain and unlocks the
+vault with it silently (via `bw unlock --passwordenv`, so it never touches disk
+or a process argument list). Combined with `BW_CLIENTID` / `BW_CLIENTSECRET`
+for headless login, cold starts become fully prompt-free.
+
+**Opt in** (prompts for the password, validates it by actually unlocking the
+vault, and only stores it on success — never accepted as a command-line
+argument, so it can't leak into shell history):
+
+```bash
+# bash / zsh — one-time explicit command...
+gi_master_password_save
+# ...or as part of a normal run
+source init.sh --remember-password
+```
+
+```powershell
+# PowerShell — one-time explicit command...
+Save-GitInitMasterPassword
+# ...or as part of a normal run
+. ./init.ps1 -RememberPassword
+```
+
+**Check / remove:**
+
+```bash
+gi_master_password_status       # is one stored?
+gi_master_password_clear        # remove it
+gi_session_clear --all          # full wipe: session + secrets + master password
+```
+
+```powershell
+Test-GitInitMasterPassword                  # is one stored?
+Remove-GitInitMasterPassword                # remove it
+Clear-GitInitSession -IncludeMasterPassword # full wipe incl. master password
+```
+
+If the stored password stops working (e.g. you changed it), it is removed from
+the keychain automatically on the first failed unlock and you fall back to the
+normal interactive prompt — it never loops on a bad credential.
+
+**Trade-off, stated plainly:** cached sessions expire; the master password
+does not. Anything that can read your unlocked login keychain / credential
+store can read it, and it works from other devices. Only opt in on machines
+where that trade is acceptable — the session/secret caching above is already
+enough to make day-to-day shells prompt-free.
 
 ---
 
@@ -145,6 +202,7 @@ winget install Rustlang.Rustup
 . ./init.ps1 -Reload        # force-reload keys even if already in env
 . ./init.ps1 -Reconfigure   # re-prompt for git config (name, email, gh user)
 . ./init.ps1 -Menu          # set up env and run the interactive create/clone menu
+. ./init.ps1 -RememberPassword  # opt-in: store the master password in the OS keychain
 ```
 
 ### Shell profile integration
@@ -183,9 +241,12 @@ echo $PROFILE
 | `Show-APIKeysConfig`               | Dump current config (path + map).                              |
 | `Save-APIKeysConfig [-Path]`       | Persist current in-memory config.                              |
 | `Get-GHUser` / `Get-GHRepositories` / `New-GHRepository` | GitHub helpers.               |
-| `Clear-GitInitSession`             | Remove session from keychain and unset env vars.               |
+| `Clear-GitInitSession`             | Remove session from keychain and unset env vars (`-IncludeMasterPassword` for a full wipe). |
 | `Save-GitInitSession`              | Manually save current `BW_SESSION` / `BWS_ACCESS_TOKEN` to keychain. |
 | `Restore-GitInitSession`           | Manually restore session from keychain into env.               |
+| `Save-GitInitMasterPassword`       | Opt-in: validate and store the bw master password in the keychain. |
+| `Remove-GitInitMasterPassword`     | Remove the stored master password from the keychain.           |
+| `Test-GitInitMasterPassword`       | `$true` if a master password is stored.                        |
 | `Save-GitInitCredential -Key -Value` | Low-level: write one credential to the keychain.             |
 | `Get-GitInitCredential -Key`       | Low-level: read one credential from the keychain.              |
 | `Remove-GitInitCredential -Key`    | Low-level: delete one credential from the keychain.            |
@@ -214,6 +275,7 @@ source ./init.sh -q             # print nothing (errors still appear on stderr)
 source ./init.sh --reload       # force key reload
 source ./init.sh --reconfigure  # re-prompt for git identity
 source ./init.sh --menu         # set up env and run the interactive create/clone menu
+source ./init.sh --remember-password  # opt-in: store the master password in the OS keychain
 ./init.sh                       # executed (not sourced) — env stays in subshell
 ```
 
@@ -288,7 +350,12 @@ fi
 | `gi_config_remove_key <name>`     | Drop a KeyMap entry by name.                         |
 | `gi_connect_bitwarden`            | Ensure `bw` is logged-in and unlocked.               |
 | `gi_get_bws_token`                | Bootstrap `BWS_ACCESS_TOKEN` from the bw vault item. |
-| `gi_session_clear`                | Remove session from keychain and unset env vars.     |
+| `gi_session_clear [--all]`        | Remove session from keychain and unset env vars (`--all` also removes the stored master password). |
+| `gi_session_save`                 | Manually save current `BW_SESSION` / `BWS_ACCESS_TOKEN` to keychain. |
+| `gi_session_restore`              | Manually restore session from keychain into env.     |
+| `gi_master_password_save`         | Opt-in: validate and store the bw master password in the keychain. |
+| `gi_master_password_clear`        | Remove the stored master password from the keychain. |
+| `gi_master_password_status`       | Report whether a master password is stored.          |
 | `gi_keychain_save <key> <value>`  | Low-level: write one credential to the OS keychain.  |
 | `gi_keychain_load <key>`          | Low-level: read one credential from the OS keychain. |
 | `gi_keychain_clear <key>`         | Low-level: delete one credential from the OS keychain. |

--- a/init.ps1
+++ b/init.ps1
@@ -4,7 +4,11 @@ param(
     [switch]$Menu,
     [switch]$Reconfigure,
     [switch]$Reload,
-    [switch]$Quiet
+    [switch]$Quiet,
+    # Opt-in: prompt once for the Bitwarden master password, validate it by
+    # unlocking the vault, and store it in the OS keychain so future unlocks
+    # never prompt. Remove it any time with Remove-GitInitMasterPassword.
+    [switch]$RememberPassword
 )
 
 $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
@@ -83,6 +87,16 @@ if ($configPath) {
     catch {
         Write-Error "Failed to load configuration: $($_.Exception.Message)"
         return
+    }
+
+    # Store the master password before loading keys so the freshly validated
+    # session is reused by the load below (no second prompt). If it cannot be
+    # stored (e.g. bw not logged in yet), continue — the normal interactive
+    # flow still works and the user can run Save-GitInitMasterPassword later.
+    if ($RememberPassword) {
+        if (-not (Save-GitInitMasterPassword)) {
+            Write-Warning "Master password not stored; continuing."
+        }
     }
 
     # Load Keys (this sets env vars like GITHUB_ACCESS_TOKEN)

--- a/init.sh
+++ b/init.sh
@@ -5,7 +5,7 @@
 # Run executed for the interactive menu, or source for the env-loading flow plus
 # the gi_* helper functions (load/clear/update keys, GitHub API helpers, etc.).
 
-GI_VERSION="0.2.0"
+GI_VERSION="0.3.0"
 MYINIT="git-init"
 
 # 0=quiet  1=normal(default)  2=verbose
@@ -334,6 +334,10 @@ gi_config_remove_key() {
 #
 # Service name used for all stored credentials:
 _GI_KEYCHAIN_SERVICE="git-init"
+# Keychain account holding the (opt-in) Bitwarden master password.
+# Only ever written by gi_master_password_save; see that function for the
+# security trade-off.
+_GI_MASTER_PW_KEY="bw_master_password"
 
 _gi_keychain_backend() {
   case "${OSTYPE:-}" in
@@ -351,8 +355,22 @@ gi_keychain_save() {
   backend=$(_gi_keychain_backend)
   case "$backend" in
     macos)
-      security add-generic-password \
-        -s "$_GI_KEYCHAIN_SERVICE" -a "$key" -w "$value" -U 2>/dev/null
+      # Passing the value as `-w <value>` argv would expose it in the process
+      # list (`ps`) for the duration of the call, so feed the whole command to
+      # `security -i` on stdin instead. The interactive parser understands
+      # backslash escapes inside double quotes but only takes single-line
+      # commands, so values with embedded newlines fall back to the argv form.
+      if [[ "$value" == *$'\n'* ]]; then
+        security add-generic-password \
+          -s "$_GI_KEYCHAIN_SERVICE" -a "$key" -w "$value" -U 2>/dev/null
+      else
+        local esc_key esc_val
+        esc_key=${key//\\/\\\\};   esc_key=${esc_key//\"/\\\"}
+        esc_val=${value//\\/\\\\}; esc_val=${esc_val//\"/\\\"}
+        printf 'add-generic-password -U -s "%s" -a "%s" -w "%s"\n' \
+          "$_GI_KEYCHAIN_SERVICE" "$esc_key" "$esc_val" \
+          | security -i >/dev/null 2>&1
+      fi
       ;;
     secret-tool)
       printf '%s' "$value" | \
@@ -404,7 +422,37 @@ gi_keychain_clear() {
   esac
 }
 
+gi_session_save() {
+  # Save the current BW_SESSION / BWS_ACCESS_TOKEN env values to the keychain.
+  if [[ -n "${BW_SESSION:-}" ]]; then
+    gi_keychain_save "bw_session" "$BW_SESSION" \
+      && echo "BW session saved to keychain." >&2
+  fi
+  if [[ -n "${BWS_ACCESS_TOKEN:-}" ]]; then
+    gi_keychain_save "bws_token" "$BWS_ACCESS_TOKEN" \
+      && echo "BWS token saved to keychain." >&2
+  fi
+  return 0
+}
+
+gi_session_restore() {
+  # Restore BW_SESSION / BWS_ACCESS_TOKEN from the keychain into the environment.
+  local _v
+  _v=$(gi_keychain_load "bw_session" 2>/dev/null || true)
+  [[ -n "$_v" ]] && export BW_SESSION="$_v"
+  _v=$(gi_keychain_load "bws_token" 2>/dev/null || true)
+  [[ -n "$_v" ]] && export BWS_ACCESS_TOKEN="$_v"
+  return 0
+}
+
 gi_session_clear() {
+  # gi_session_clear [--all]
+  # Clears the cached session, BWS token, and secret values. The stored master
+  # password (see gi_master_password_save) is deliberately kept unless --all is
+  # given: sessions are expiring caches, the password is a deliberate opt-in.
+  local include_master=0
+  [[ "${1:-}" == "--all" ]] && include_master=1
+
   gi_keychain_clear "bw_session"
   gi_keychain_clear "bws_token"
   unset BW_SESSION BWS_ACCESS_TOKEN
@@ -417,7 +465,108 @@ gi_session_clear() {
     done < <(printf '%s' "$_GI_CONFIG_JSON" | jq -r '.KeyMap[].SecretId')
   fi
 
+  if (( include_master )); then
+    gi_keychain_clear "$_GI_MASTER_PW_KEY"
+    echo "Master password removed from keychain." >&2
+  fi
+
   echo "Session cleared from keychain." >&2
+}
+
+#------------------------------------------------------------------------------
+# Master password storage (explicit opt-in)
+#------------------------------------------------------------------------------
+# Trade-off: cached sessions expire, the master password does not. Anything
+# that can read your unlocked login keychain can read it. Storing it buys
+# fully prompt-free unlocks (combined with BW_CLIENTID/BW_CLIENTSECRET login,
+# a fully headless cold start); only opt in on machines where that trade is
+# acceptable. Nothing here ever stores the password without gi_master_password_save
+# being called (or the --remember-password flag, which calls it).
+
+gi_master_password_save() {
+  # Prompts for the Bitwarden master password (never accepted as an argument:
+  # argv leaks into shell history and `ps`), validates it by actually unlocking
+  # the vault, and only stores it after a successful unlock.
+  local backend
+  backend=$(_gi_keychain_backend)
+  if [[ "$backend" == "none" ]]; then
+    echo "No keychain backend available; refusing to store the master password." >&2
+    echo "Install libsecret (provides secret-tool) on Linux." >&2
+    return 1
+  fi
+  command -v bw &>/dev/null || { echo "Bitwarden CLI 'bw' not found in PATH." >&2; return 1; }
+
+  local bw_status
+  bw_status=$(bw status 2>/dev/null | jq -r '.status' 2>/dev/null || echo "")
+  if [[ "$bw_status" == "unauthenticated" || -z "$bw_status" ]]; then
+    echo "Bitwarden CLI is not logged in, so the password cannot be validated." >&2
+    echo "Run gi_connect_bitwarden (or 'bw login') first." >&2
+    return 1
+  fi
+
+  local pw
+  printf "Bitwarden master password (will be stored in the OS keychain): "
+  read -rs pw || true
+  echo
+  [[ -n "$pw" ]] || { echo "Empty password; nothing stored." >&2; return 1; }
+
+  local session
+  if ! session=$(BW_PASSWORD="$pw" bw unlock --passwordenv BW_PASSWORD --raw 2>/dev/null) \
+     || [[ -z "$session" ]]; then
+    unset pw
+    echo "That password did not unlock the vault; nothing stored." >&2
+    return 1
+  fi
+
+  # The unlock we just did is a perfectly good session — keep it.
+  export BW_SESSION="$session"
+  gi_keychain_save "bw_session" "$session" \
+    && _gi_log_e 2 "BW session saved to keychain."
+
+  if ! gi_keychain_save "$_GI_MASTER_PW_KEY" "$pw"; then
+    unset pw
+    echo "Failed to write the master password to the keychain." >&2
+    return 1
+  fi
+  # Read back to verify: the hardened macOS path pipes through `security -i`,
+  # whose exit status is not a reliable success signal.
+  local check
+  check=$(gi_keychain_load "$_GI_MASTER_PW_KEY" 2>/dev/null || true)
+  if [[ "$check" != "$pw" ]]; then
+    unset pw check
+    gi_keychain_clear "$_GI_MASTER_PW_KEY"
+    echo "Stored master password failed read-back verification; check your keychain backend." >&2
+    return 1
+  fi
+  unset pw check
+  echo "Master password saved to keychain. Remove it with gi_master_password_clear." >&2
+}
+
+gi_master_password_clear() {
+  local existing
+  existing=$(gi_keychain_load "$_GI_MASTER_PW_KEY" 2>/dev/null || true)
+  if [[ -z "$existing" ]]; then
+    echo "No master password stored in the keychain."
+    return 0
+  fi
+  gi_keychain_clear "$_GI_MASTER_PW_KEY"
+  echo "Master password removed from keychain."
+}
+
+gi_master_password_status() {
+  local backend
+  backend=$(_gi_keychain_backend)
+  echo "Keychain backend: $backend"
+  if [[ "$backend" == "none" ]]; then
+    echo "No master password stored (no keychain backend)."
+    return 1
+  fi
+  if [[ -n "$(gi_keychain_load "$_GI_MASTER_PW_KEY" 2>/dev/null || true)" ]]; then
+    echo "A master password is stored in the OS keychain."
+    return 0
+  fi
+  echo "No master password stored."
+  return 1
 }
 
 #==============================================================================
@@ -473,12 +622,33 @@ gi_connect_bitwarden() {
 
   if [[ "$bw_status" == "locked" ]]; then
     # Vault locked — the cached session (if any) has expired; clear it and unlock.
+    # Note: the stored master password is NOT purged here; being locked (or even
+    # logged out) does not make the password wrong. It is only removed when it
+    # actually fails to unlock, or explicitly by the user.
     gi_keychain_clear "bw_session"
     gi_keychain_clear "bws_token"
     unset BW_SESSION BWS_ACCESS_TOKEN
-    _gi_log 1 "🔓 Unlocking Bitwarden vault..."
-    local session
-    session=$(bw unlock --raw) || { echo "Unlock failed." >&2; return 1; }
+    local session=""
+    # A stored master password (opt-in via gi_master_password_save) unlocks
+    # without prompting. The env-var handoff never touches disk or argv. If it
+    # stops working (password changed), remove it so we never loop on a bad
+    # credential, then fall through to the interactive prompt.
+    local _stored_pw
+    _stored_pw=$(gi_keychain_load "$_GI_MASTER_PW_KEY" 2>/dev/null || true)
+    if [[ -n "$_stored_pw" ]]; then
+      _gi_log 1 "🔓 Unlocking Bitwarden vault with stored master password..."
+      session=$(BW_PASSWORD="$_stored_pw" bw unlock --passwordenv BW_PASSWORD --raw 2>/dev/null) \
+        || session=""
+      if [[ -z "$session" ]]; then
+        gi_keychain_clear "$_GI_MASTER_PW_KEY"
+        echo "Stored master password no longer unlocks the vault; removed it from the keychain." >&2
+      fi
+    fi
+    unset _stored_pw
+    if [[ -z "$session" ]]; then
+      _gi_log 1 "🔓 Unlocking Bitwarden vault..."
+      session=$(bw unlock --raw) || { echo "Unlock failed." >&2; return 1; }
+    fi
     [[ -n "$session" ]] || { echo "Empty session returned by bw unlock." >&2; return 1; }
     export BW_SESSION="$session"
     gi_keychain_save "bw_session" "$session" \
@@ -950,8 +1120,8 @@ gi_print_help() {
 git-init $GI_VERSION
 
 Usage:
-  source init.sh [--reload] [--reconfigure] [--menu] [-v] [-q]
-  ./init.sh     [--reload] [--reconfigure] [-v] [-q]
+  source init.sh [--reload] [--reconfigure] [--menu] [--remember-password] [-v] [-q]
+  ./init.sh     [--reload] [--reconfigure] [--remember-password] [-v] [-q]
 
 Options:
   --reload        Force reload of API keys even if env vars are already set,
@@ -960,6 +1130,11 @@ Options:
                   reading existing values.
   --menu          (sourced only) Set up keys/credential helper and run the
                   interactive menu.
+  --remember-password
+                  Opt-in: prompt once for the Bitwarden master password,
+                  validate it by unlocking the vault, and store it in the OS
+                  keychain so future unlocks never prompt. Remove it any time
+                  with gi_master_password_clear.
   -v, --verbose   Print per-key load messages and keychain save confirmations.
   -q, --quiet     Print nothing (errors to stderr still appear).
   -h, --help      Show this help.
@@ -981,7 +1156,14 @@ Functions exposed when sourced:
     gi_config_remove_key <name>
 
   OS keychain session (macOS Keychain / Linux libsecret):
-    gi_session_clear              Remove session from keychain and unset env vars
+    gi_session_clear [--all]      Remove session from keychain and unset env vars
+                                  (--all also removes the stored master password)
+    gi_session_save               Save current BW_SESSION / BWS_ACCESS_TOKEN to keychain
+    gi_session_restore            Restore BW_SESSION / BWS_ACCESS_TOKEN from keychain
+    gi_master_password_save       Opt-in: store the bw master password in the keychain
+                                  (validated with 'bw unlock' before storing)
+    gi_master_password_clear      Remove the stored master password from the keychain
+    gi_master_password_status     Report whether a master password is stored
     gi_keychain_save <key> <val>  Low-level: write a credential to the keychain
     gi_keychain_load <key>        Low-level: read a credential from the keychain
     gi_keychain_clear <key>       Low-level: delete a credential from the keychain
@@ -1000,16 +1182,17 @@ EOF
 _gi_main_body() {
   set -euo pipefail
 
-  local reconfigure=0 reload=0 show_menu=0
+  local reconfigure=0 reload=0 show_menu=0 remember_password=0
   _GI_VERBOSITY=1   # reset to default; flags below may override
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --reconfigure)    reconfigure=1; shift ;;
-      --reload)         reload=1; shift ;;
-      --menu)           show_menu=1; shift ;;
-      -v|--verbose)     _GI_VERBOSITY=2; shift ;;
-      -q|--quiet)       _GI_VERBOSITY=0; shift ;;
-      -h|--help)        gi_print_help; return 0 ;;
+      --reconfigure)        reconfigure=1; shift ;;
+      --reload)             reload=1; shift ;;
+      --menu)               show_menu=1; shift ;;
+      --remember-password)  remember_password=1; shift ;;
+      -v|--verbose)         _GI_VERBOSITY=2; shift ;;
+      -q|--quiet)           _GI_VERBOSITY=0; shift ;;
+      -h|--help)            gi_print_help; return 0 ;;
       *) echo "Unknown argument: $1" >&2; gi_print_help >&2; return 2 ;;
     esac
   done
@@ -1041,6 +1224,16 @@ _gi_main_body() {
     echo "KeyMap in $_GI_CONFIG_PATH is empty." >&2
     echo "Add an entry with: gi_config_add_key <name> <bws-secret-uuid> <ENV_VAR>" >&2
     return 1
+  fi
+
+  # Store the master password before loading keys so the freshly validated
+  # session is reused by the load below (no second prompt). If it cannot be
+  # stored (e.g. bw not logged in yet), continue — the normal interactive
+  # flow still works and the user can run gi_master_password_save later.
+  if (( remember_password )); then
+    if ! gi_master_password_save; then
+      echo "Master password not stored; continuing." >&2
+    fi
   fi
 
   local should_load=0


### PR DESCRIPTION
## Summary

Adds opt-in support for storing the Bitwarden master password in the OS keychain, enabling fully prompt-free vault unlocks when combined with API key authentication. The password is validated before storage and automatically removed if it stops working.

## Key Changes

- **Master password storage functions** (`gi_master_password_save`, `gi_master_password_clear`, `gi_master_password_status` in bash; `Save-GitInitMasterPassword`, `Remove-GitInitMasterPassword`, `Test-GitInitMasterPassword` in PowerShell)
  - Password is prompted interactively (never accepted as argument to prevent shell history leaks)
  - Validated by actually unlocking the vault before storage
  - Handed to `bw unlock --passwordenv` via environment variable, never via disk or process arguments
  - Automatically removed if it fails to unlock (e.g., after password change)

- **Enhanced `gi_connect_bitwarden` / `Connect-Bitwarden`** to use stored master password for silent unlocks when available, falling back to interactive prompt if needed

- **Improved macOS keychain security** in `gi_keychain_save` / `Save-GitInitCredential`
  - Values without newlines are now piped through `security -i` stdin instead of passed as arguments, preventing exposure in `ps` output
  - Backslash and quote escaping for the stdin path

- **Session management updates**
  - `gi_session_clear --all` / `Clear-GitInitSession -IncludeMasterPassword` flag to optionally remove stored master password
  - New `gi_session_save` / `gi_session_restore` functions for manual session management
  - Master password deliberately kept separate from session clearing (sessions are expiring caches; password is explicit opt-in)

- **CLI integration**
  - `--remember-password` / `-RememberPassword` flag to prompt for and store master password during initialization
  - Updated help text and documentation

- **Version bumps**: init.sh 0.2.0 → 0.3.0, APIKeys.psd1 0.1.1 → 0.2.0

## Implementation Details

- Trade-off explicitly documented: master password persists in keychain (unlike sessions), so anything reading the unlocked credential store can access it. Only recommended for machines where this is acceptable.
- Password validation is mandatory before storage—never stored without successful `bw unlock`.
- Graceful degradation: if keychain backend unavailable or `bw` not logged in, the feature is skipped but normal flows continue.
- Read-back verification after storage to catch keychain backend failures.

https://claude.ai/code/session_01Q1b7Fbtv6yWmVPBTzrTYts